### PR TITLE
Cached RpcCloseVent

### DIFF
--- a/Modules/ExtendedPlayerControl.cs
+++ b/Modules/ExtendedPlayerControl.cs
@@ -410,13 +410,23 @@ static class ExtendedPlayerControl
             }
         }
     }
-    public static List<Vent> GetVentsFromClosest(this PlayerControl player)
+    public static List<Vent> GetVentsFromClosest(this PlayerControl player, float maxDistance = 0f)
     {
-        Vector2 playerpos = player.transform.position;
-        List<Vent> vents = [.. ShipStatus.Instance.AllVents];
+        Vector2 playerpos = player.GetTruePosition();
+        List<Vent> vents = new(ShipStatus.Instance.AllVents);
+
+        // Calculate distances and filter if maxDistance > 0
+        if (maxDistance > 0f)
+        {
+            vents = vents.Where(v => Vector2.Distance(playerpos, v.transform.position) <= maxDistance).ToList();
+        }
+
+        // Sort remaining vents by distance
         vents.Sort((v1, v2) => Vector2.Distance(playerpos, v1.transform.position).CompareTo(Vector2.Distance(playerpos, v2.transform.position)));
+
         return vents;
     }
+
 
     /// <summary>
     /// Update vent interaction if player again can use vent

--- a/Patches/PlayerControlPatch.cs
+++ b/Patches/PlayerControlPatch.cs
@@ -17,6 +17,7 @@ using TOHE.Roles.Impostor;
 using TOHE.Roles.Neutral;
 using TOHE.Roles.Core;
 using static TOHE.Translator;
+using TOHE.Patches;
 
 namespace TOHE;
 
@@ -1550,6 +1551,7 @@ class CoEnterVentPatch
             try
             {
                 __instance?.RpcBootFromVent(id);
+                __instance?.myPlayer.RpcCloseVent();
             }
             catch
             {

--- a/Patches/onGameStartedPatch.cs
+++ b/Patches/onGameStartedPatch.cs
@@ -94,6 +94,7 @@ internal class ChangeRoleSettings
             GameStartManagerPatch.GameStartManagerUpdatePatch.AlredyBegin = false;
 
             VentSystemDeterioratePatch.LastClosestVent = [];
+            VentSystemDeterioratePatch.LastClosedAtVentId = [];
 
             ChatManager.ResetHistory();
             ReportDeadBodyPatch.CanReport = [];
@@ -181,7 +182,8 @@ internal class ChangeRoleSettings
 
                 ReportDeadBodyPatch.CanReport[pc.PlayerId] = true;
                 ReportDeadBodyPatch.WaitReport[pc.PlayerId] = [];
-                VentSystemDeterioratePatch.LastClosestVent[pc.PlayerId] = 0;
+                VentSystemDeterioratePatch.LastClosestVent[pc.PlayerId] = -2;
+                VentSystemDeterioratePatch.LastClosedAtVentId[pc.PlayerId] = -2;
 
                 pc.cosmetics.nameText.text = pc.name;
 


### PR DESCRIPTION
Previously RpcCloseVent is sent by host at every fixed update to every block vent players
I add some codes to send the close vent only when the closest vent to a player changed.

Sorry I merged latest dev 2.1.0 into my branch. Just check the last commit

Known issues:
if players in a game is too little (like only 2-3 players)
then the amount of vents that can be closed to a player is the player count in that game.
So if we get too little players, some may still be able to vent before host could update the close vent calls