### PR TITLE
Better Among Us RPC support

### DIFF
--- a/Modules/BAUPlayersData.cs
+++ b/Modules/BAUPlayersData.cs
@@ -1,0 +1,79 @@
+﻿
+namespace TOHE.Modules;
+
+public class BAUPlayersData
+{
+    private Dictionary<NetworkedPlayerInfo, string> _players = new Dictionary<NetworkedPlayerInfo, string>();
+
+    public string this[NetworkedPlayerInfo key]
+    {
+        get
+        {
+            CleanUpNullEntries();
+            return _players.ContainsKey(key) ? _players[key] : null;
+        }
+        set
+        {
+            CleanUpNullEntries();
+            if (key != null)
+            {
+                _players[key] = value;
+            }
+        }
+    }
+
+    private void CleanUpNullEntries()
+    {
+        var keysToRemove = _players.Where(kvp => kvp.Key == null).Select(kvp => kvp.Key).ToList();
+        foreach (var key in keysToRemove)
+        {
+            _players.Remove(key);
+        }
+    }
+
+    public bool TryGetValue(NetworkedPlayerInfo key, out string value)
+    {
+        CleanUpNullEntries();
+        return _players.TryGetValue(key, out value);
+    }
+
+    public void Add(NetworkedPlayerInfo key, string value)
+    {
+        CleanUpNullEntries();
+        if (key != null)
+        {
+            _players[key] = value;
+        }
+    }
+
+    public bool Remove(NetworkedPlayerInfo key)
+    {
+        CleanUpNullEntries();
+        return _players.Remove(key);
+    }
+
+    public bool ContainsKey(NetworkedPlayerInfo key)
+    {
+        CleanUpNullEntries();
+        return _players.ContainsKey(key);
+    }
+
+    public Dictionary<NetworkedPlayerInfo, string>.KeyCollection Keys
+    {
+        get
+        {
+            CleanUpNullEntries();
+            return _players.Keys;
+        }
+    }
+
+    public Dictionary<NetworkedPlayerInfo, string>.ValueCollection Values
+    {
+        get
+        {
+            CleanUpNullEntries();
+            return _players.Values;
+        }
+    }
+}
+

--- a/Modules/RPC.cs
+++ b/Modules/RPC.cs
@@ -74,7 +74,7 @@ enum CustomRPC : byte // 193/255 USED
     SetLoversPlayers,
     SetExecutionerTarget,
     RemoveExecutionerTarget,
-    BetterCheck, // BetterAmongUs (BAU) RPC, This is sent to allow other BAU users know who's using BAU!
+    BetterCheck = 150, // BetterAmongUs (BAU) RPC, This is sent to allow other BAU users know who's using BAU!
     SendFireworkerState,
     SetCurrentDousingTarget,
     SetEvilTrackerTarget,

--- a/Modules/RPC.cs
+++ b/Modules/RPC.cs
@@ -22,6 +22,7 @@ enum CustomRPC : byte // 193/255 USED
     VersionCheck = 80,
     RequestRetryVersionCheck = 81,
     SyncCustomSettings = 100, // AUM use 101 rpc
+    BetterCheck = 150, // BetterAmongUs (BAU) RPC, This is sent to allow other BAU users know who's using BAU!
     SetDeathReason = 102,
     EndGame,
     PlaySound,
@@ -74,8 +75,7 @@ enum CustomRPC : byte // 193/255 USED
     SetLoversPlayers,
     SetExecutionerTarget,
     RemoveExecutionerTarget,
-    BetterCheck = 150, // BetterAmongUs (BAU) RPC, This is sent to allow other BAU users know who's using BAU!
-    SendFireworkerState,
+    SendFireworkerState = 151, // Skip 150
     SetCurrentDousingTarget,
     SetEvilTrackerTarget,
     SetDrawPlayer,

--- a/Modules/RPC.cs
+++ b/Modules/RPC.cs
@@ -19,10 +19,10 @@ enum CustomRPC : byte // 193/255 USED
 {
     // RpcCalls can increase with each AU version
     // On version 2024.6.18 the last id in RpcCalls: 65
+    BetterCheck = 150, // BetterAmongUs (BAU) RPC, This is sent to allow other BAU users know who's using BAU!
     VersionCheck = 80,
     RequestRetryVersionCheck = 81,
     SyncCustomSettings = 100, // AUM use 101 rpc
-    BetterCheck = 150, // BetterAmongUs (BAU) RPC, This is sent to allow other BAU users know who's using BAU!
     SetDeathReason = 102,
     EndGame,
     PlaySound,

--- a/Modules/RPC.cs
+++ b/Modules/RPC.cs
@@ -74,6 +74,7 @@ enum CustomRPC : byte // 193/255 USED
     SetLoversPlayers,
     SetExecutionerTarget,
     RemoveExecutionerTarget,
+    BetterCheck, // BetterAmongUs (BAU) RPC, This is sent to allow other BAU users know who's using BAU!
     SendFireworkerState,
     SetCurrentDousingTarget,
     SetEvilTrackerTarget,
@@ -144,7 +145,8 @@ internal class RPCHandlerPatch
         or CustomRPC.PresidentEnd
         or CustomRPC.SetSwapperVotes
         or CustomRPC.DumpLog
-        or CustomRPC.SetFriendCode;
+        or CustomRPC.SetFriendCode
+        or CustomRPC.BetterCheck;
     public static bool Prefix(PlayerControl __instance, [HarmonyArgument(0)] byte callId, [HarmonyArgument(1)] MessageReader reader)
     {
         var rpcType = (RpcCalls)callId;
@@ -500,6 +502,30 @@ internal class RPCHandlerPatch
                 break;
             case CustomRPC.RemoveExecutionerTarget:
                 Executioner.ReceiveRPC(reader, SetTarget: false);
+                break;
+            case CustomRPC.BetterCheck: // Better Among Us RPC
+                {
+                    var SetBetterUser = reader.ReadBoolean(); // Used to set player as better user, boolean is used for a future for BAU later on.
+                    var IsBetterHost = reader.ReadBoolean(); // Used to set the player as better host, this should never be flagged for a TOHE lobby, if it is it's a spoofed RPC
+                    var Signature = reader.ReadString(); // Used to verify that the RPC isn't spoofed, only possible in BAU mod due to a special signature that can't really be replicated easily
+                    var Version = reader.ReadString(); // Used to read players BAU version
+
+                    if (IsBetterHost)
+                    {
+                        EAC.Report(__instance, "BetterCheck set as BetterHost");
+                        EAC.HandleCheat(__instance, "BetterCheck set as BetterHost");
+                        break;
+                    }
+
+                    if (string.IsNullOrEmpty(Signature) || string.IsNullOrEmpty(Version))
+                    {
+                        EAC.Report(__instance, "BetterCheck invalid info");
+                        EAC.HandleCheat(__instance, "BetterCheck invalid info");
+                        break;
+                    }
+
+                    Main.BAUPlayers[__instance.Data] = __instance.Data.Puid;
+                }
                 break;
             case CustomRPC.SendFireworkerState:
                 Fireworker.ReceiveRPC(reader);

--- a/Patches/PlayerControlPatch.cs
+++ b/Patches/PlayerControlPatch.cs
@@ -1236,6 +1236,13 @@ class FixedUpdateInNormalGamePatch
                         __instance.cosmetics.nameText.text = ver.tag == $"{ThisAssembly.Git.Commit}({ThisAssembly.Git.Branch})" ? $"<color=#87cefa>{__instance.name}</color>" : $"<color=#ffff00><size=1.2>{ver.tag}</size>\n{__instance?.name}</color>";
                     else __instance.cosmetics.nameText.text = $"<color=#ff0000><size=1.2>v{ver.version}</size>\n{__instance?.name}</color>";
                 }
+                if (Main.BAUPlayers.TryGetValue(__instance.Data, out var puid)) // Set name color for BAU users
+                {
+                    if (puid == __instance.Data.Puid)
+                    {
+                        __instance.cosmetics.nameText.text = $"<color=#0dff00>{__instance.name}</color>";
+                    }
+                }
                 else __instance.cosmetics.nameText.text = __instance?.Data?.PlayerName;
             }
             if (GameStates.IsInGame)

--- a/main.cs
+++ b/main.cs
@@ -10,6 +10,7 @@ using System.IO;
 using System.Reflection;
 using System.Text;
 using System.Text.Json;
+using TOHE.Modules;
 using TOHE.Roles.AddOns;
 using TOHE.Roles.Core;
 using TOHE.Roles.Double;
@@ -104,6 +105,7 @@ public class Main : BasePlugin
     public static ConfigEntry<bool> AutoRehost { get; private set; }
 
     public static Dictionary<int, PlayerVersion> playerVersion = [];
+    public static BAUPlayersData BAUPlayers = new();
     //Preset Name Options
     public static ConfigEntry<string> Preset1 { get; private set; }
     public static ConfigEntry<string> Preset2 { get; private set; }


### PR DESCRIPTION
# Added support for the Better Among Us RPC
- When a player is a BAU user their name will be green and will not be kicked for sending a untrusted RPC!
- This is added because i am currently working on support for BAU users being able to be in TOHE lobbies