### PR TITLE
New Option:Dictator use Command /exp to Expel instead of Voting 

### DIFF
--- a/Patches/ChatCommandPatch.cs
+++ b/Patches/ChatCommandPatch.cs
@@ -67,7 +67,8 @@ internal class ChatCommands
         if (Nemesis.NemesisMsgCheck(PlayerControl.LocalPlayer, text)) goto Canceled;
         if (Retributionist.RetributionistMsgCheck(PlayerControl.LocalPlayer, text)) goto Canceled;
         if (Medium.MsMsg(PlayerControl.LocalPlayer, text)) goto Canceled;
-        if (PlayerControl.LocalPlayer.GetRoleClass() is Swapper sw && sw.SwapMsg(PlayerControl.LocalPlayer, text)) goto Canceled; 
+        if (PlayerControl.LocalPlayer.GetRoleClass() is Swapper sw && sw.SwapMsg(PlayerControl.LocalPlayer, text)) goto Canceled;
+        if (PlayerControl.LocalPlayer.GetRoleClass() is Dictator dt && dt.ExilePlayer(PlayerControl.LocalPlayer, text)) goto Canceled;
         Directory.CreateDirectory(modTagsFiles);
         Directory.CreateDirectory(vipTagsFiles);
         Directory.CreateDirectory(sponsorTagsFiles);
@@ -1901,6 +1902,7 @@ internal class ChatCommands
         if (Medium.MsMsg(player, text)) { Logger.Info($"Is Medium command", "OnReceiveChat"); return; }
         if (Nemesis.NemesisMsgCheck(player, text)) { Logger.Info($"Is Nemesis Revenge command", "OnReceiveChat"); return; }
         if (Retributionist.RetributionistMsgCheck(player, text)) { Logger.Info($"Is Retributionist Revenge command", "OnReceiveChat"); return; }
+        if (player.GetRoleClass() is Dictator dt && dt.ExilePlayer(player, text)) { canceled = true; Logger.Info($"Is Dictator command", "OnReceiveChat"); return; }
 
         Directory.CreateDirectory(modTagsFiles);
         Directory.CreateDirectory(vipTagsFiles);

--- a/Patches/MeetingHudPatch.cs
+++ b/Patches/MeetingHudPatch.cs
@@ -58,7 +58,7 @@ class CheckForEndVotingPatch
                     }
                 }
 
-                if (Dictator.CheckVotingForTarget(pc, pva))
+                if (Dictator.CheckVotingForTarget(pc, pva) && !Dictator.ChangeCommandToExpel.GetBool())
                 {
                     var voteTarget = GetPlayerById(pva.VotedFor);
                     TryAddAfterMeetingDeathPlayers(PlayerState.DeathReason.Suicide, pc.PlayerId);
@@ -410,7 +410,7 @@ class CheckForEndVotingPatch
     }
 
     // Credit：https://github.com/music-discussion/TownOfHost-TheOtherRoles
-    private static void ConfirmEjections(NetworkedPlayerInfo exiledPlayer, bool AntiBlackoutStore = false)
+    public static void ConfirmEjections(NetworkedPlayerInfo exiledPlayer, bool AntiBlackoutStore = false)
     {
         if (!AmongUsClient.Instance.AmHost) return;
         if (exiledPlayer == null) return;
@@ -609,7 +609,7 @@ class CheckForEndVotingPatch
         }
         CheckForDeathOnExile(deathReason, [.. AddedIdList]);
     }
-    private static void CheckForDeathOnExile(PlayerState.DeathReason deathReason, params byte[] playerIds)
+    public static void CheckForDeathOnExile(PlayerState.DeathReason deathReason, params byte[] playerIds)
     {
         if (deathReason == PlayerState.DeathReason.Vote)
         {

--- a/Patches/MeetingHudPatch.cs
+++ b/Patches/MeetingHudPatch.cs
@@ -713,7 +713,7 @@ class CastVotePatch
                 case CustomRoles.Dictator:
                     if (target.Is(CustomRoles.Solsticer))
                     {
-                        SendMessage(GetString("VoteSolsticer"), srcPlayerId);
+                        SendMessage(GetString("ExpelSolsticer"), srcPlayerId);
                         __instance.RpcClearVoteDelay(voter.GetClientId());
                         return false;
                     }

--- a/Resources/Lang/en_US.json
+++ b/Resources/Lang/en_US.json
@@ -1021,7 +1021,7 @@
   "SlothInfoLong": "(Add-ons):\nThe Sloth's default movement speed is slower than others.\n(Speed depends on the setting of the Host)",
   "ProhibitedInfoLong": "(Add-ons):\nAs the Prohibited, you have specific vents that you can't use.\nHow many vents are disabled depends on the Host's settings.",
   "EavesdropperInfoLong": "(Add-ons):\nAs the Eavesdropper, you have a chance to read other role/addon information-based messages like Mortician or Sleuth.",
-  
+
   "ShowTextOverlay": "Text Overlay",
   "Overlay.GuesserMode": "<size=50%>Guesser Mode</size>",
   "Overlay.NoGameEnd": "<size=50%>No Game End</size>",
@@ -1540,6 +1540,8 @@
 
   "VigilanteNotify": "You have become the very thing you swore to destroy",
 
+  "DictatorChangeCommandToExpel": "<color=#df9b00>Dictator</color> use Command to expell instad of vote",
+  "DictatorExpelSelf": "WAIT WAIT WAIT WAT THE HELLLLLL Bro really just want to expel himself",
   "DoctorTaskCompletedBatteryCharge": "Battery Duration",
   "SnitchEnableTargetArrow": "See Arrow Towards Target",
   "SnitchCanGetArrowColor": "See Colored Arrows based on Team Colors",
@@ -3662,7 +3664,7 @@
   "SolsticerOnMeeting": "You witnessed too many deaths! Next round you will have {0} more short task!",
   "SolsticerTitle": "Solsticer",
   "GuessSolsticer": "Sorry, but you can not guess Solsticer!",
-  "VoteSolsticer": "Sorry, but you can not vote Solsticer!",
+  "ExpelSolsticer": "Sorry, but you can not expel Solsticer!",
   "SolsticerTasksReset": "Your tasks get reset!",
   "SolsticerMisGuessed": "You just misguessed! You are no longer allowed to guess.",
   "SolsticerGuessMax": "Because you already misguessed, you are no longer allowed to guess.",

--- a/Roles/Crewmate/Dictator.cs
+++ b/Roles/Crewmate/Dictator.cs
@@ -1,4 +1,9 @@
-﻿using static TOHE.Options;
+﻿using System;
+using TOHE.Modules.ChatManager;
+using static TOHE.Options;
+using static TOHE.Utils;
+using static TOHE.Translator;
+using static UnityEngine.GraphicsBuffer;
 
 namespace TOHE.Roles.Crewmate;
 
@@ -12,10 +17,11 @@ internal class Dictator : RoleBase
     public override CustomRoles ThisRoleBase => CustomRoles.Crewmate;
     public override Custom_RoleType ThisRoleType => Custom_RoleType.CrewmatePower;
     //==================================================================\\
-
+    public static OptionItem ChangeCommandToExpel;
     public override void SetupCustomOption()
     {
         SetupRoleOptions(Id, TabGroup.CrewmateRoles, CustomRoles.Dictator);
+        ChangeCommandToExpel = BooleanOptionItem.Create(Id + 10, "DictatorChangeCommandToExpel", false, TabGroup.CrewmateRoles, false).SetParent(Options.CustomRoleSpawnChances[CustomRoles.Dictator]);
     }
 
     public override void Init()
@@ -29,4 +35,100 @@ internal class Dictator : RoleBase
 
     public static bool CheckVotingForTarget(PlayerControl pc, PlayerVoteArea pva)
         => pc.Is(CustomRoles.Dictator) && pva.DidVote && pc.PlayerId != pva.VotedFor && pva.VotedFor < 253 && !pc.Data.IsDead;
+    public bool ExilePlayer(PlayerControl pc,string msg)
+    {
+        if (!ChangeCommandToExpel.GetBool()) return false;
+        if (!AmongUsClient.Instance.AmHost) return false;
+        if (!GameStates.IsMeeting || pc == null || GameStates.IsExilling) return false;
+        if (!pc.IsAlive()) return false;
+        if (!pc.Is(CustomRoles.Dictator)) return false;
+        int operate = 0; // 1:ID 2:猜测
+        msg = msg.ToLower().TrimStart().TrimEnd();
+        if (ChatManager.CheckCommond(ref msg, "id|guesslist|gl编号|玩家编号|玩家id|id列表|玩家列表|列表|所有id|全部id||編號|玩家編號")) operate = 1;
+        else if (ChatManager.CheckCommond(ref msg, "exp|expel|独裁|獨裁", false)) operate = 2;
+        else return false;
+        List<MeetingHud.VoterState> statesList = [];
+        MeetingHud.VoterState[] states;
+        if (operate == 1)
+        {
+            Utils.SendMessage(GuessManager.GetFormatString(), pc.PlayerId);
+           // GuessManager.TryHideMsg();
+           // ChatManager.SendPreviousMessagesToAll();
+            return true;
+        }
+        if (operate == 2)
+        {
+            if (msg.StartsWith("/")) msg = msg.Replace("/", string.Empty);
+            var targetid = 0;
+            if (int.TryParse(msg, out int num))
+            {
+                targetid = Convert.ToByte(num);
+            }
+            var target = Utils.GetPlayerById(targetid);
+            if (target == pc) 
+            {
+                pc.ShowInfoMessage(false, GetString("DictatorExpelSelf"));
+                return true;
+            }
+            if (!target.IsAlive())
+            {
+                return true;
+            }
+            if (target.Is(CustomRoles.Solsticer))
+            {
+                pc.ShowInfoMessage(false,GetString("ExpelSolsticer"));
+                MeetingHud.Instance.RpcClearVoteDelay(pc.GetClientId());
+                return true;
+            }
+            statesList.Add(new()
+            {
+                VoterId = pc.PlayerId,
+                VotedForId = target.PlayerId
+            });
+            states = [.. statesList];
+            var exiled = target.Data;
+            var isBlackOut = AntiBlackout.BlackOutIsActive;
+            CheckForEndVotingPatch.TryAddAfterMeetingDeathPlayers(PlayerState.DeathReason.Suicide, pc.PlayerId);
+            ExileControllerWrapUpPatch.AntiBlackout_LastExiled = exiled;
+            Main.LastVotedPlayerInfo = exiled;
+            AntiBlackout.ExilePlayerId = exiled.PlayerId;
+            if (AntiBlackout.BlackOutIsActive)
+            {
+                if (isBlackOut)
+                    MeetingHud.Instance.AntiBlackRpcVotingComplete(states, exiled, false);
+                else
+                    MeetingHud.Instance.RpcVotingComplete(statesList.ToArray(), exiled, false);
+                if (exiled != null)
+                {
+                    AntiBlackout.ShowExiledInfo = isBlackOut;
+                    CheckForEndVotingPatch.ConfirmEjections(exiled, isBlackOut);
+                    MeetingHud.Instance.RpcVotingComplete(statesList.ToArray(), null, true);
+                    MeetingHud.Instance.RpcClose();
+                }
+            }
+            else
+            {
+                MeetingHud.Instance.RpcVotingComplete(states, exiled, false);
+
+                if (exiled != null)
+                {
+                    CheckForEndVotingPatch.ConfirmEjections(exiled);
+                }
+            }
+
+            Logger.Info($"{target.GetNameWithRole()} expelled by Dictator", "Dictator");
+
+            CheckForEndVotingPatch.CheckForDeathOnExile(PlayerState.DeathReason.Vote, target.PlayerId);
+
+            Logger.Info("Dictatorial vote, forced closure of the meeting", "Special Phase");
+
+            target.SetRealKiller(pc);
+
+        }
+        return true;
+    }
+    public override string PVANameText(PlayerVoteArea pva, PlayerControl seer, PlayerControl target)
+    => seer.IsAlive() && target.IsAlive() ? ColorString(GetRoleColor(CustomRoles.Dictator), target.PlayerId.ToString()) + " " + pva.NameText.text : "";
+    public override string NotifyPlayerName(PlayerControl seer, PlayerControl target, string TargetPlayerName = "", bool IsForMeeting = false) 
+        => IsForMeeting && ChangeCommandToExpel.GetBool() ? ColorString(GetRoleColor(CustomRoles.Dictator), target.PlayerId.ToString()) + " " + TargetPlayerName : "";
 }


### PR DESCRIPTION
Option let dictator can use the command /exp or /expel to expel someone instead of voting.
Dictator cant vote normally.This Option can make dictator can vote normally