### PR TITLE
Jester can't get Susceptible

### DIFF
--- a/Modules/CustomRolesHelper.cs
+++ b/Modules/CustomRolesHelper.cs
@@ -1059,6 +1059,11 @@ public static class CustomRolesHelper
                     || pc.Is(CustomRoles.Sloth))
                     return false;
                 break;
+            
+             case CustomRoles.Susceptible:
+                if (pc.Is(CustomRoles.Jester))
+                    return false;
+                break;
 
             case CustomRoles.Sloth:
                 if (pc.Is(CustomRoles.Swooper) 


### PR DESCRIPTION
Jester doesn't win if they have susceptible because it changes the death reason from "ejected" to something else which causes the Jester to not win by getting ejected,