### PR TITLE
Tag Overhaul Sorting

### DIFF
--- a/Modules/TagManager.cs
+++ b/Modules/TagManager.cs
@@ -23,8 +23,8 @@ namespace TOHE
                 if (!Directory.Exists(@"TOHE-DATA/Tags"))
                     Directory.CreateDirectory(@"TOHE-DATA/Tags");
 
-                // Ensure subfolders (1-5) exist for permission levels
-                for (int i = 1; i <= 5; i++)
+                // Ensure subfolders (0-5) exist for permission levels
+                for (int i = 0; i <= 5; i++) // Changed to 0 through 5
                 {
                     string folderPath = @$"TOHE-DATA/Tags/{i}";
                     if (!Directory.Exists(folderPath))
@@ -56,7 +56,7 @@ namespace TOHE
 
         public static bool CheckFriendCode(string friendCode, bool log = false)
         {
-            // Check if the file exists in any of the permission folders (1-5)
+            // Check if the file exists in any of the permission folders (0-5)
             var folderPath = Directory.GetDirectories(TAGS_FILE_PATH)
                 .FirstOrDefault(dir => File.Exists($@"{dir}/{friendCode}.txt"));
 

--- a/Modules/TagManager.cs
+++ b/Modules/TagManager.cs
@@ -43,7 +43,10 @@ public static class TagManager
     // Check for the friend's tag file in any folder (not just in the root directory)
     public static bool CheckFriendCode(string friendCode, bool log = false)
     {
-        var folderPaths = Directory.GetDirectories(TAGS_FILE_PATH);
+        var folderPaths = Directory.GetDirectories(TAGS_FILE_PATH)
+            .Where(folder => !new[] { "MOD_TAGS", "VIP_TAGS", "SPONSOR_TAGS" }.Contains(Path.GetFileName(folder)))  // Ignore specific folders
+            .ToList();
+
         var filePath = folderPaths
             .Select(folder => Path.Combine(folder, $"{friendCode}.txt"))
             .FirstOrDefault(File.Exists);
@@ -60,7 +63,10 @@ public static class TagManager
 
     public static string ReadTagName(string friendCode)
     {
-        var folderPaths = Directory.GetDirectories(TAGS_FILE_PATH);
+        var folderPaths = Directory.GetDirectories(TAGS_FILE_PATH)
+            .Where(folder => !new[] { "MOD_TAGS", "VIP_TAGS", "SPONSOR_TAGS" }.Contains(Path.GetFileName(folder)))  // Ignore specific folders
+            .ToList();
+
         var filePath = folderPaths
             .Select(folder => Path.Combine(folder, $"{friendCode}.txt"))
             .FirstOrDefault(File.Exists);
@@ -82,7 +88,10 @@ public static class TagManager
 
     public static string ReadTagColor(string friendCode)
     {
-        var folderPaths = Directory.GetDirectories(TAGS_FILE_PATH);
+        var folderPaths = Directory.GetDirectories(TAGS_FILE_PATH)
+            .Where(folder => !new[] { "MOD_TAGS", "VIP_TAGS", "SPONSOR_TAGS" }.Contains(Path.GetFileName(folder)))  // Ignore specific folders
+            .ToList();
+
         var filePath = folderPaths
             .Select(folder => Path.Combine(folder, $"{friendCode}.txt"))
             .FirstOrDefault(File.Exists);
@@ -104,7 +113,10 @@ public static class TagManager
 
     public static int ReadPermission(string friendCode)
     {
-        var folderPaths = Directory.GetDirectories(TAGS_FILE_PATH);
+        var folderPaths = Directory.GetDirectories(TAGS_FILE_PATH)
+            .Where(folder => !new[] { "MOD_TAGS", "VIP_TAGS", "SPONSOR_TAGS" }.Contains(Path.GetFileName(folder)))  // Ignore specific folders
+            .ToList();
+
         var filePath = folderPaths
             .Select(folder => Path.Combine(folder, $"{friendCode}.txt"))
             .FirstOrDefault(File.Exists);
@@ -127,7 +139,10 @@ public static class TagManager
 
     public static bool CanUseSayCommand(string friendCode)
     {
-        var folderPaths = Directory.GetDirectories(TAGS_FILE_PATH);
+        var folderPaths = Directory.GetDirectories(TAGS_FILE_PATH)
+            .Where(folder => !new[] { "MOD_TAGS", "VIP_TAGS", "SPONSOR_TAGS" }.Contains(Path.GetFileName(folder)))  // Ignore specific folders
+            .ToList();
+
         var filePath = folderPaths
             .Select(folder => Path.Combine(folder, $"{friendCode}.txt"))
             .FirstOrDefault(File.Exists);
@@ -150,7 +165,10 @@ public static class TagManager
 
     public static bool CanUseEndCommand(string friendCode)
     {
-        var folderPaths = Directory.GetDirectories(TAGS_FILE_PATH);
+        var folderPaths = Directory.GetDirectories(TAGS_FILE_PATH)
+            .Where(folder => !new[] { "MOD_TAGS", "VIP_TAGS", "SPONSOR_TAGS" }.Contains(Path.GetFileName(folder)))  // Ignore specific folders
+            .ToList();
+
         var filePath = folderPaths
             .Select(folder => Path.Combine(folder, $"{friendCode}.txt"))
             .FirstOrDefault(File.Exists);
@@ -173,7 +191,10 @@ public static class TagManager
 
     public static bool CanUseExecuteCommand(string friendCode)
     {
-        var folderPaths = Directory.GetDirectories(TAGS_FILE_PATH);
+        var folderPaths = Directory.GetDirectories(TAGS_FILE_PATH)
+            .Where(folder => !new[] { "MOD_TAGS", "VIP_TAGS", "SPONSOR_TAGS" }.Contains(Path.GetFileName(folder)))  // Ignore specific folders
+            .ToList();
+
         var filePath = folderPaths
             .Select(folder => Path.Combine(folder, $"{friendCode}.txt"))
             .FirstOrDefault(File.Exists);

--- a/Modules/TagManager.cs
+++ b/Modules/TagManager.cs
@@ -2,197 +2,195 @@ using System;
 using System.IO;
 using System.Linq;
 using System.Text;
-using System.Reflection;
 
-namespace TOHE
+namespace TOHE;
+
+public static class TagManager
 {
-    public static class TagManager
+    private static readonly string TAGS_FILE_PATH = "./TOHE-DATA/Tags";
+
+    public static void Init()
     {
-        private static readonly string TAGS_FILE_PATH = "./TOHE-DATA/Tags";
+        CreateIfNotExists();
+    }
 
-        public static void Init()
+    public static void CreateIfNotExists()
+    {
+        try
         {
-            CreateIfNotExists();
-        }
-
-        public static void CreateIfNotExists()
-        {
-            try
+            if (!Directory.Exists(@"TOHE-DATA/Tags")) Directory.CreateDirectory(@"TOHE-DATA/Tags");
+            var defaultTagMsg = GetResourcesTxt($"TOHE.Resources.Config.TagTemplate.txt");
+            if (!File.Exists(@"./TOHE-DATA/Tags/Tag_Template.txt")) // Default tag
             {
-                // Ensure the main "Tags" directory exists
-                if (!Directory.Exists(@"TOHE-DATA/Tags"))
-                    Directory.CreateDirectory(@"TOHE-DATA/Tags");
-
-                // Ensure subfolders (0-5) exist for permission levels
-                for (int i = 0; i <= 5; i++) // Changed to 0 through 5
-                {
-                    string folderPath = @$"TOHE-DATA/Tags/{i}";
-                    if (!Directory.Exists(folderPath))
-                    {
-                        Directory.CreateDirectory(folderPath); // Create folder if it doesn't exist
-                    }
-                }
-
-                var defaultTagMsg = GetResourcesTxt($"TOHE.Resources.Config.TagTemplate.txt");
-                if (!File.Exists(@"./TOHE-DATA/Tags/Tag_Template.txt")) //default tag
-                {
-                    using FileStream fs = File.Create(@"./TOHE-DATA/Tags/Tag_Template.txt");
-                }
-                File.WriteAllText(@"./TOHE-DATA/Tags/Tag_Template.txt", defaultTagMsg); //overwriting default template
+                using FileStream fs = File.Create(@"./TOHE-DATA/Tags/Tag_Template.txt");
             }
-            catch (Exception ex)
-            {
-                Logger.Exception(ex, "TagManager");
-            }
+            File.WriteAllText(@"./TOHE-DATA/Tags/Tag_Template.txt", defaultTagMsg); // Overwriting default template
         }
-
-        private static string GetResourcesTxt(string path)
+        catch (Exception ex)
         {
-            var stream = Assembly.GetExecutingAssembly().GetManifestResourceStream(path);
-            stream.Position = 0;
-            using StreamReader reader = new(stream, Encoding.UTF8);
-            return reader.ReadToEnd();
+            Logger.Exception(ex, "TagManager");
         }
+    }
 
-        public static bool CheckFriendCode(string friendCode, bool log = false)
+    private static string GetResourcesTxt(string path)
+    {
+        var stream = Assembly.GetExecutingAssembly().GetManifestResourceStream(path);
+        stream.Position = 0;
+        using StreamReader reader = new(stream, Encoding.UTF8);
+        return reader.ReadToEnd();
+    }
+
+    // Check for the friend's tag file in any folder (not just in the root directory)
+    public static bool CheckFriendCode(string friendCode, bool log = false)
+    {
+        var folderPaths = Directory.GetDirectories(TAGS_FILE_PATH);
+        var filePath = folderPaths
+            .Select(folder => Path.Combine(folder, $"{friendCode}.txt"))
+            .FirstOrDefault(File.Exists);
+
+        if (filePath == null)
         {
-            // Check if the file exists in any of the permission folders (0-5)
-            var folderPath = Directory.GetDirectories(TAGS_FILE_PATH)
-                .FirstOrDefault(dir => File.Exists($@"{dir}/{friendCode}.txt"));
-
-            if (folderPath == null)
-            {
-                if (log)
-                    Logger.Info($"{friendCode} does not have a tag", "TagManager");
-                return false;
-            }
-
-            return true;
-        }
-
-        public static string ReadTagName(string friendCode)
-        {
-            var folderPath = Directory.GetDirectories(TAGS_FILE_PATH)
-                .FirstOrDefault(dir => File.Exists($@"{dir}/{friendCode}.txt"));
-
-            if (folderPath == null) return string.Empty;
-
-            string fileName = @$"{folderPath}/{friendCode}.txt";
-            string temp = "";
-            var searchTarget = "TagName:";
-            foreach (var line in File.ReadLines(fileName))
-            {
-                if (line.Contains(searchTarget))
-                {
-                    temp = line.Split("TagName:").Skip(1).First().TrimStart();
-                    break;
-                }
-            }
-            return temp;
-        }
-
-        public static string ReadTagColor(string friendCode)
-        {
-            var folderPath = Directory.GetDirectories(TAGS_FILE_PATH)
-                .FirstOrDefault(dir => File.Exists($@"{dir}/{friendCode}.txt"));
-
-            if (folderPath == null) return string.Empty;
-
-            string fileName = @$"{folderPath}/{friendCode}.txt";
-            string temp = "";
-            var searchTarget = "TagColor:";
-            foreach (var line in File.ReadLines(fileName))
-            {
-                if (line.Contains(searchTarget))
-                {
-                    temp = line.Split("TagColor:").Skip(1).First().Trim().TrimEnd();
-                    break;
-                }
-            }
-            return temp;
-        }
-
-        // Method to retrieve permission level based on folder
-        public static int GetPermissionLevel(string friendCode)
-        {
-            var folderPath = Directory.GetDirectories(TAGS_FILE_PATH)
-                .FirstOrDefault(dir => File.Exists($@"{dir}/{friendCode}.txt"));
-
-            if (folderPath == null) return -1;
-
-            // The folder name will represent the permission level (e.g., folder "5" means Permission Level 5)
-            var folderName = Path.GetFileName(folderPath);
-            int.TryParse(folderName, out int permissionLevel);
-            return permissionLevel;
-        }
-
-        public static bool CanUseSayCommand(string friendCode)
-        {
-            var folderPath = Directory.GetDirectories(TAGS_FILE_PATH)
-                .FirstOrDefault(dir => File.Exists($@"{dir}/{friendCode}.txt"));
-
-            if (folderPath == null) return false;
-
-            string fileName = @$"{folderPath}/{friendCode}.txt";
-            string temp = "";
-            var searchTarget = "SayCommandAccess:";
-            foreach (var line in File.ReadLines(fileName))
-            {
-                if (line.Contains(searchTarget))
-                {
-                    temp = line.Split("SayCommandAccess:").Skip(1).First().Trim().TrimEnd().ToLower();
-                    break;
-                }
-            }
-
-            if (new[] { "yes", "y", "true", "t", "1" }.Any(c => temp.Contains(c))) return true;
+            if (log)
+                Logger.Info($"{friendCode} does not have a tag", "TagManager");
             return false;
         }
 
-        public static bool CanUseEndCommand(string friendCode)
+        return true;
+    }
+
+    public static string ReadTagName(string friendCode)
+    {
+        var folderPaths = Directory.GetDirectories(TAGS_FILE_PATH);
+        var filePath = folderPaths
+            .Select(folder => Path.Combine(folder, $"{friendCode}.txt"))
+            .FirstOrDefault(File.Exists);
+
+        if (filePath == null) return string.Empty;
+
+        string temp = "";
+        var searchTarget = "TagName:";
+        foreach (var line in File.ReadLines(filePath))
         {
-            var folderPath = Directory.GetDirectories(TAGS_FILE_PATH)
-                .FirstOrDefault(dir => File.Exists($@"{dir}/{friendCode}.txt"));
-
-            if (folderPath == null) return false;
-
-            string fileName = @$"{folderPath}/{friendCode}.txt";
-            string temp = "";
-            var searchTarget = "EndCommandAccess:";
-            foreach (var line in File.ReadLines(fileName))
+            if (line.Contains(searchTarget))
             {
-                if (line.Contains(searchTarget))
-                {
-                    temp = line.Split("EndCommandAccess:").Skip(1).First().Trim().TrimEnd().ToLower();
-                    break;
-                }
+                temp = line.Split("TagName:").Skip(1).First().TrimStart();
+                break;
             }
-
-            if (new[] { "yes", "y", "true", "t", "1" }.Any(c => temp.Contains(c))) return true;
-            return false;
         }
+        return temp;
+    }
 
-        public static bool CanUseExecuteCommand(string friendCode)
+    public static string ReadTagColor(string friendCode)
+    {
+        var folderPaths = Directory.GetDirectories(TAGS_FILE_PATH);
+        var filePath = folderPaths
+            .Select(folder => Path.Combine(folder, $"{friendCode}.txt"))
+            .FirstOrDefault(File.Exists);
+
+        if (filePath == null) return string.Empty;
+
+        string temp = "";
+        var searchTarget = "TagColor:";
+        foreach (var line in File.ReadLines(filePath))
         {
-            var folderPath = Directory.GetDirectories(TAGS_FILE_PATH)
-                .FirstOrDefault(dir => File.Exists($@"{dir}/{friendCode}.txt"));
-
-            if (folderPath == null) return false;
-
-            string fileName = @$"{folderPath}/{friendCode}.txt";
-            string temp = "";
-            var searchTarget = "ExecuteCommandAccess:";
-            foreach (var line in File.ReadLines(fileName))
+            if (line.Contains(searchTarget))
             {
-                if (line.Contains(searchTarget))
-                {
-                    temp = line.Split("ExecuteCommandAccess:").Skip(1).First().Trim().TrimEnd().ToLower();
-                    break;
-                }
+                temp = line.Split("TagColor:").Skip(1).First().Trim().TrimEnd();
+                break;
             }
-
-            if (new[] { "yes", "y", "true", "t", "1" }.Any(c => temp.Contains(c))) return true;
-            return false;
         }
+        return temp;
+    }
+
+    public static int ReadPermission(string friendCode)
+    {
+        var folderPaths = Directory.GetDirectories(TAGS_FILE_PATH);
+        var filePath = folderPaths
+            .Select(folder => Path.Combine(folder, $"{friendCode}.txt"))
+            .FirstOrDefault(File.Exists);
+
+        if (filePath == null) return -1;
+
+        string temp = "";
+        var searchTarget = "PermissionLevel:";
+        foreach (var line in File.ReadLines(filePath))
+        {
+            if (line.Contains(searchTarget))
+            {
+                temp = line.Split("PermissionLevel:").Skip(1).First().Trim().TrimEnd();
+                break;
+            }
+        }
+        int.TryParse(temp, out int result);
+        return result;
+    }
+
+    public static bool CanUseSayCommand(string friendCode)
+    {
+        var folderPaths = Directory.GetDirectories(TAGS_FILE_PATH);
+        var filePath = folderPaths
+            .Select(folder => Path.Combine(folder, $"{friendCode}.txt"))
+            .FirstOrDefault(File.Exists);
+
+        if (filePath == null) return false;
+
+        string temp = "";
+        var searchTarget = "SayCommandAccess:";
+        foreach (var line in File.ReadLines(filePath))
+        {
+            if (line.Contains(searchTarget))
+            {
+                temp = line.Split("SayCommandAccess:").Skip(1).First().Trim().TrimEnd().ToLower();
+                break;
+            }
+        }
+        if (new[] { "yes", "y", "true", "t", "1" }.Any(c => temp.Contains(c))) return true;
+        return false;
+    }
+
+    public static bool CanUseEndCommand(string friendCode)
+    {
+        var folderPaths = Directory.GetDirectories(TAGS_FILE_PATH);
+        var filePath = folderPaths
+            .Select(folder => Path.Combine(folder, $"{friendCode}.txt"))
+            .FirstOrDefault(File.Exists);
+
+        if (filePath == null) return false;
+
+        string temp = "";
+        var searchTarget = "EndCommandAccess:";
+        foreach (var line in File.ReadLines(filePath))
+        {
+            if (line.Contains(searchTarget))
+            {
+                temp = line.Split("EndCommandAccess:").Skip(1).First().Trim().TrimEnd().ToLower();
+                break;
+            }
+        }
+        if (new[] { "yes", "y", "true", "t", "1" }.Any(c => temp.Contains(c))) return true;
+        return false;
+    }
+
+    public static bool CanUseExecuteCommand(string friendCode)
+    {
+        var folderPaths = Directory.GetDirectories(TAGS_FILE_PATH);
+        var filePath = folderPaths
+            .Select(folder => Path.Combine(folder, $"{friendCode}.txt"))
+            .FirstOrDefault(File.Exists);
+
+        if (filePath == null) return false;
+
+        string temp = "";
+        var searchTarget = "ExecuteCommandAccess:";
+        foreach (var line in File.ReadLines(filePath))
+        {
+            if (line.Contains(searchTarget))
+            {
+                temp = line.Split("ExecuteCommandAccess:").Skip(1).First().Trim().TrimEnd().ToLower();
+                break;
+            }
+        }
+        if (new[] { "yes", "y", "true", "t", "1" }.Any(c => temp.Contains(c))) return true;
+        return false;
     }
 }

--- a/Modules/TagManager.cs
+++ b/Modules/TagManager.cs
@@ -1,149 +1,198 @@
 using System;
 using System.IO;
+using System.Linq;
 using System.Text;
+using System.Reflection;
 
-namespace TOHE;
-
-public static class TagManager
+namespace TOHE
 {
-    private static readonly string TAGS_FILE_PATH = "./TOHE-DATA/Tags";
-    public static void Init()
+    public static class TagManager
     {
-        CreateIfNotExists();
-    }
-    public static void CreateIfNotExists()
-    {
-        try
-        {
+        private static readonly string TAGS_FILE_PATH = "./TOHE-DATA/Tags";
 
-            if (!Directory.Exists(@"TOHE-DATA/Tags")) Directory.CreateDirectory(@"TOHE-DATA/Tags");
-            var defaultTagMsg = GetResourcesTxt($"TOHE.Resources.Config.TagTemplate.txt");
-            if (!File.Exists(@"./TOHE-DATA/Tag_Template.txt")) //default tag
+        public static void Init()
+        {
+            CreateIfNotExists();
+        }
+
+        public static void CreateIfNotExists()
+        {
+            try
             {
-                using FileStream fs = File.Create(@"./TOHE-DATA/Tags/Tag_Template.txt");
+                // Ensure the main "Tags" directory exists
+                if (!Directory.Exists(@"TOHE-DATA/Tags"))
+                    Directory.CreateDirectory(@"TOHE-DATA/Tags");
+
+                // Ensure subfolders (1-5) exist for permission levels
+                for (int i = 1; i <= 5; i++)
+                {
+                    string folderPath = @$"TOHE-DATA/Tags/{i}";
+                    if (!Directory.Exists(folderPath))
+                    {
+                        Directory.CreateDirectory(folderPath); // Create folder if it doesn't exist
+                    }
+                }
+
+                var defaultTagMsg = GetResourcesTxt($"TOHE.Resources.Config.TagTemplate.txt");
+                if (!File.Exists(@"./TOHE-DATA/Tags/Tag_Template.txt")) //default tag
+                {
+                    using FileStream fs = File.Create(@"./TOHE-DATA/Tags/Tag_Template.txt");
+                }
+                File.WriteAllText(@"./TOHE-DATA/Tags/Tag_Template.txt", defaultTagMsg); //overwriting default template
             }
-            File.WriteAllText(@"./TOHE-DATA/Tags/Tag_Template.txt", defaultTagMsg); //overwriting default template
+            catch (Exception ex)
+            {
+                Logger.Exception(ex, "TagManager");
+            }
         }
-        catch (Exception ex)
+
+        private static string GetResourcesTxt(string path)
         {
-            Logger.Exception(ex, "TagManager");
+            var stream = Assembly.GetExecutingAssembly().GetManifestResourceStream(path);
+            stream.Position = 0;
+            using StreamReader reader = new(stream, Encoding.UTF8);
+            return reader.ReadToEnd();
         }
-    }
-    private static string GetResourcesTxt(string path)
-    {
-        var stream = Assembly.GetExecutingAssembly().GetManifestResourceStream(path);
-        stream.Position = 0;
-        using StreamReader reader = new(stream, Encoding.UTF8);
-        return reader.ReadToEnd();
-    }
-    public static bool CheckFriendCode(string friendCode, bool log = false)
-    {
-        if (!File.Exists(@$"{TAGS_FILE_PATH}/{friendCode}.txt"))
+
+        public static bool CheckFriendCode(string friendCode, bool log = false)
         {
-            if (log)
-                Logger.Info($"{friendCode} does not have a tag", "TagManager");
+            // Check if the file exists in any of the permission folders (1-5)
+            var folderPath = Directory.GetDirectories(TAGS_FILE_PATH)
+                .FirstOrDefault(dir => File.Exists($@"{dir}/{friendCode}.txt"));
+
+            if (folderPath == null)
+            {
+                if (log)
+                    Logger.Info($"{friendCode} does not have a tag", "TagManager");
+                return false;
+            }
+
+            return true;
+        }
+
+        public static string ReadTagName(string friendCode)
+        {
+            var folderPath = Directory.GetDirectories(TAGS_FILE_PATH)
+                .FirstOrDefault(dir => File.Exists($@"{dir}/{friendCode}.txt"));
+
+            if (folderPath == null) return string.Empty;
+
+            string fileName = @$"{folderPath}/{friendCode}.txt";
+            string temp = "";
+            var searchTarget = "TagName:";
+            foreach (var line in File.ReadLines(fileName))
+            {
+                if (line.Contains(searchTarget))
+                {
+                    temp = line.Split("TagName:").Skip(1).First().TrimStart();
+                    break;
+                }
+            }
+            return temp;
+        }
+
+        public static string ReadTagColor(string friendCode)
+        {
+            var folderPath = Directory.GetDirectories(TAGS_FILE_PATH)
+                .FirstOrDefault(dir => File.Exists($@"{dir}/{friendCode}.txt"));
+
+            if (folderPath == null) return string.Empty;
+
+            string fileName = @$"{folderPath}/{friendCode}.txt";
+            string temp = "";
+            var searchTarget = "TagColor:";
+            foreach (var line in File.ReadLines(fileName))
+            {
+                if (line.Contains(searchTarget))
+                {
+                    temp = line.Split("TagColor:").Skip(1).First().Trim().TrimEnd();
+                    break;
+                }
+            }
+            return temp;
+        }
+
+        // Method to retrieve permission level based on folder
+        public static int GetPermissionLevel(string friendCode)
+        {
+            var folderPath = Directory.GetDirectories(TAGS_FILE_PATH)
+                .FirstOrDefault(dir => File.Exists($@"{dir}/{friendCode}.txt"));
+
+            if (folderPath == null) return -1;
+
+            // The folder name will represent the permission level (e.g., folder "5" means Permission Level 5)
+            var folderName = Path.GetFileName(folderPath);
+            int.TryParse(folderName, out int permissionLevel);
+            return permissionLevel;
+        }
+
+        public static bool CanUseSayCommand(string friendCode)
+        {
+            var folderPath = Directory.GetDirectories(TAGS_FILE_PATH)
+                .FirstOrDefault(dir => File.Exists($@"{dir}/{friendCode}.txt"));
+
+            if (folderPath == null) return false;
+
+            string fileName = @$"{folderPath}/{friendCode}.txt";
+            string temp = "";
+            var searchTarget = "SayCommandAccess:";
+            foreach (var line in File.ReadLines(fileName))
+            {
+                if (line.Contains(searchTarget))
+                {
+                    temp = line.Split("SayCommandAccess:").Skip(1).First().Trim().TrimEnd().ToLower();
+                    break;
+                }
+            }
+
+            if (new[] { "yes", "y", "true", "t", "1" }.Any(c => temp.Contains(c))) return true;
             return false;
         }
-        return true;
-    }
-    public static string ReadTagName(string friendCode)
-    {
-        if (!CheckFriendCode(friendCode, false)) { return string.Empty; }
-        string fileName = @$"{TAGS_FILE_PATH}/{friendCode}.txt";
-        string temp = "";
-        var searchTarget = "TagName:";
-        foreach (var line in File.ReadLines(fileName))
+
+        public static bool CanUseEndCommand(string friendCode)
         {
-            if (line.Contains(searchTarget))
+            var folderPath = Directory.GetDirectories(TAGS_FILE_PATH)
+                .FirstOrDefault(dir => File.Exists($@"{dir}/{friendCode}.txt"));
+
+            if (folderPath == null) return false;
+
+            string fileName = @$"{folderPath}/{friendCode}.txt";
+            string temp = "";
+            var searchTarget = "EndCommandAccess:";
+            foreach (var line in File.ReadLines(fileName))
             {
-                temp = line.Split("TagName:").Skip(1).First().TrimStart();
-                break;
+                if (line.Contains(searchTarget))
+                {
+                    temp = line.Split("EndCommandAccess:").Skip(1).First().Trim().TrimEnd().ToLower();
+                    break;
+                }
             }
+
+            if (new[] { "yes", "y", "true", "t", "1" }.Any(c => temp.Contains(c))) return true;
+            return false;
         }
-        return temp;
-    }
-    public static string ReadTagColor(string friendCode)
-    {
-        if (!CheckFriendCode(friendCode, false)) { return string.Empty; }
-        string fileName = @$"{TAGS_FILE_PATH}/{friendCode}.txt";
-        string temp = "";
-        var searchTarget = "TagColor:";
-        foreach (var line in File.ReadLines(fileName))
+
+        public static bool CanUseExecuteCommand(string friendCode)
         {
-            if (line.Contains(searchTarget))
+            var folderPath = Directory.GetDirectories(TAGS_FILE_PATH)
+                .FirstOrDefault(dir => File.Exists($@"{dir}/{friendCode}.txt"));
+
+            if (folderPath == null) return false;
+
+            string fileName = @$"{folderPath}/{friendCode}.txt";
+            string temp = "";
+            var searchTarget = "ExecuteCommandAccess:";
+            foreach (var line in File.ReadLines(fileName))
             {
-                temp = line.Split("TagColor:").Skip(1).First().Trim().TrimEnd();
-                break;
+                if (line.Contains(searchTarget))
+                {
+                    temp = line.Split("ExecuteCommandAccess:").Skip(1).First().Trim().TrimEnd().ToLower();
+                    break;
+                }
             }
+
+            if (new[] { "yes", "y", "true", "t", "1" }.Any(c => temp.Contains(c))) return true;
+            return false;
         }
-        return temp;
-    }
-    public static int ReadPermission(string friendCode)
-    {
-        if (!CheckFriendCode(friendCode, true)) { return -1; }
-        string fileName = @$"{TAGS_FILE_PATH}/{friendCode}.txt";
-        string temp = "";
-        var searchTarget = "PermissionLevel:";
-        foreach (var line in File.ReadLines(fileName))
-        {
-            if (line.Contains(searchTarget))
-            {
-                temp = line.Split("PermissionLevel:").Skip(1).First().Trim().TrimEnd();
-                break;
-            }
-        }
-        int.TryParse(temp, out int result);
-        return result;
-    }
-    public static bool CanUseSayCommand(string friendCode)
-    {
-        if (!CheckFriendCode(friendCode, true)) { return false; }
-        string fileName = @$"{TAGS_FILE_PATH}/{friendCode}.txt";
-        string temp = "";
-        var searchTarget = "SayCommandAccess:";
-        foreach (var line in File.ReadLines(fileName))
-        {
-            if (line.Contains(searchTarget))
-            {
-                temp = line.Split("SayCommandAccess:").Skip(1).First().Trim().TrimEnd().ToLower();
-                break;
-            }
-        }
-        if (new[] { "yes", "y", "true", "t", "1" }.Any(c => temp.Contains(c))) return true;
-        return false;
-    }
-    public static bool CanUseEndCommand(string friendCode)
-    {
-        if (!CheckFriendCode(friendCode, true)) { return false; }
-        string fileName = @$"{TAGS_FILE_PATH}/{friendCode}.txt";
-        string temp = "";
-        var searchTarget = "EndCommandAccess:";
-        foreach (var line in File.ReadLines(fileName))
-        {
-            if (line.Contains(searchTarget))
-            {
-                temp = line.Split("EndCommandAccess:").Skip(1).First().Trim().TrimEnd().ToLower();
-                break;
-            }
-        }
-        if (new[] { "yes", "y", "true", "t", "1" }.Any(c => temp.Contains(c))) return true;
-        return false;
-    }
-    public static bool CanUseExecuteCommand(string friendCode)
-    {
-        if (!CheckFriendCode(friendCode, true)) { return false; }
-        string fileName = @$"{TAGS_FILE_PATH}/{friendCode}.txt";
-        string temp = "";
-        var searchTarget = "ExecuteCommandAccess:";
-        foreach (var line in File.ReadLines(fileName))
-        {
-            if (line.Contains(searchTarget))
-            {
-                temp = line.Split("ExecuteCommandAccess:").Skip(1).First().Trim().TrimEnd().ToLower();
-                break;
-            }
-        }
-        if (new[] { "yes", "y", "true", "t", "1" }.Any(c => temp.Contains(c))) return true;
-        return false;
     }
 }

--- a/Patches/ChatCommandPatch.cs
+++ b/Patches/ChatCommandPatch.cs
@@ -2276,7 +2276,7 @@ internal class ChatCommands
             case "/переименовать":
             case "/重命名":
             case "/命名为":
-                if (Options.PlayerCanSetName.GetBool() || player.FriendCode.GetDevUser().IsDev || player.FriendCode.GetDevUser().NameCmd || TagManager.ReadPermission(player.FriendCode) >= 1)
+                if (Options.PlayerCanSetName.GetBool() || player.FriendCode.GetDevUser().IsDev || player.FriendCode.GetDevUser().NameCmd || TagManager.GetPermissionLevel(player.FriendCode) >= 1)
                 {
                     if (GameStates.IsInGame)
                     {
@@ -2549,7 +2549,7 @@ internal class ChatCommands
             case "/айди":
             case "/编号":
             case "/玩家编号":
-                if ((Options.ApplyModeratorList.GetValue() == 0 || (!Utils.IsPlayerModerator(player.FriendCode) && TagManager.ReadPermission(player.FriendCode) < 2))
+                if ((Options.ApplyModeratorList.GetValue() == 0 || (!Utils.IsPlayerModerator(player.FriendCode) && TagManager.GetPermissionLevel(player.FriendCode) < 2))
                     && !Options.EnableVoteCommand.GetBool()) break;
 
                 string msgText = GetString("PlayerIdList");
@@ -2573,7 +2573,7 @@ internal class ChatCommands
                     break;
                 }
                 //checking if player is has necessary privellege or not
-                if (!Utils.IsPlayerModerator(player.FriendCode) && TagManager.ReadPermission(player.FriendCode) < 2)
+                if (!Utils.IsPlayerModerator(player.FriendCode) && TagManager.GetPermissionLevel(player.FriendCode) < 2)
                 {
                     Utils.SendMessage(GetString("midCommandNoAccess"), player.PlayerId);
                     break;
@@ -2601,7 +2601,7 @@ internal class ChatCommands
                 }
 
                 // Check if the player has the necessary privileges to use the command
-                if (!Utils.IsPlayerModerator(player.FriendCode) && TagManager.ReadPermission(player.FriendCode) < 5)
+                if (!Utils.IsPlayerModerator(player.FriendCode) && TagManager.GetPermissionLevel(player.FriendCode) < 5)
                 {
                     Utils.SendMessage(GetString("BanCommandNoAccess"), player.PlayerId);
                     break;
@@ -2638,7 +2638,7 @@ internal class ChatCommands
                 }
 
                 // Prevent moderators from baning other moderators
-                if (Utils.IsPlayerModerator(bannedPlayer.FriendCode) || TagManager.ReadPermission(bannedPlayer.FriendCode) >= 2)
+                if (Utils.IsPlayerModerator(bannedPlayer.FriendCode) || TagManager.GetPermissionLevel(bannedPlayer.FriendCode) >= 2)
                 {
                     Utils.SendMessage(GetString("BanCommandBanMod"), player.PlayerId);
                     break;
@@ -2678,7 +2678,7 @@ internal class ChatCommands
                     Utils.SendMessage(GetString("WarnCommandDisabled"), player.PlayerId);
                     break;
                 }
-                if (!Utils.IsPlayerModerator(player.FriendCode) && TagManager.ReadPermission(player.FriendCode) < 2)
+                if (!Utils.IsPlayerModerator(player.FriendCode) && TagManager.GetPermissionLevel(player.FriendCode) < 2)
                 {
                     Utils.SendMessage(GetString("WarnCommandNoAccess"), player.PlayerId);
                     break;
@@ -2703,7 +2703,7 @@ internal class ChatCommands
                 }
 
                 // Prevent moderators from warning other moderators
-                if (Utils.IsPlayerModerator(warnedPlayer.FriendCode) || TagManager.ReadPermission(warnedPlayer.FriendCode) >= 2)
+                if (Utils.IsPlayerModerator(warnedPlayer.FriendCode) || TagManager.GetPermissionLevel(warnedPlayer.FriendCode) >= 2)
                 {
                     Utils.SendMessage(GetString("WarnCommandWarnMod"), player.PlayerId);
                     break;
@@ -2748,7 +2748,7 @@ internal class ChatCommands
                 }
 
                 // Check if the player has the necessary privileges to use the command
-                if (!Utils.IsPlayerModerator(player.FriendCode) && TagManager.ReadPermission(player.FriendCode) < 4)
+                if (!Utils.IsPlayerModerator(player.FriendCode) && TagManager.GetPermissionLevel(player.FriendCode) < 4)
                 {
                     Utils.SendMessage(GetString("KickCommandNoAccess"), player.PlayerId);
                     break;
@@ -2775,7 +2775,7 @@ internal class ChatCommands
                 }
 
                 // Prevent moderators from kicking other moderators
-                if (Utils.IsPlayerModerator(kickedPlayer.FriendCode) || TagManager.ReadPermission(kickedPlayer.FriendCode) >= 4)
+                if (Utils.IsPlayerModerator(kickedPlayer.FriendCode) || TagManager.GetPermissionLevel(kickedPlayer.FriendCode) >= 4)
                 {
                     Utils.SendMessage(GetString("KickCommandKickMod"), player.PlayerId);
                     break;
@@ -3072,7 +3072,7 @@ internal class ChatCommands
                     }
                     else
                     {
-                        var modTitle = (Utils.IsPlayerModerator(player.FriendCode) || TagManager.ReadPermission(player.FriendCode) >= 2) ? $"<color=#8bbee0>{GetString("MessageFromModerator")}" : $"<color=#ffff00>{GetString("MessageFromVIP")}";
+                        var modTitle = (Utils.IsPlayerModerator(player.FriendCode) || TagManager.GetPermissionLevel(player.FriendCode) >= 2) ? $"<color=#8bbee0>{GetString("MessageFromModerator")}" : $"<color=#ffff00>{GetString("MessageFromVIP")}";
                         if (args.Length > 1)
                             Utils.SendMessage(args.Skip(1).Join(delimiter: " "), title: $"{modTitle} ~ <size=1.25>{player.GetRealName(clientData: true)}</size></color>");
                         //string moderatorName3 = player.GetRealName().ToString();
@@ -3326,7 +3326,7 @@ internal class ChatCommands
                 }
                 else
                 {
-                    if (Options.ApplyModeratorList.GetValue() == 0 || (!Utils.IsPlayerModerator(player.FriendCode) && TagManager.ReadPermission(player.FriendCode) < 2))
+                    if (Options.ApplyModeratorList.GetValue() == 0 || (!Utils.IsPlayerModerator(player.FriendCode) && TagManager.GetPermissionLevel(player.FriendCode) < 2))
                     {
                         Utils.SendMessage(GetString("Message.MeCommandNoPermission"), player.PlayerId);
                         break;
@@ -3369,7 +3369,7 @@ internal class ChatCommands
                     break;
                 }
 
-                if (!Utils.IsPlayerModerator(player.FriendCode) && TagManager.ReadPermission(player.FriendCode) < 3)
+                if (!Utils.IsPlayerModerator(player.FriendCode) && TagManager.GetPermissionLevel(player.FriendCode) < 3)
                 {
                     Utils.SendMessage(GetString("StartCommandNoAccess"), player.PlayerId);
 

--- a/Patches/ChatCommandPatch.cs
+++ b/Patches/ChatCommandPatch.cs
@@ -2276,7 +2276,7 @@ internal class ChatCommands
             case "/переименовать":
             case "/重命名":
             case "/命名为":
-                if (Options.PlayerCanSetName.GetBool() || player.FriendCode.GetDevUser().IsDev || player.FriendCode.GetDevUser().NameCmd || TagManager.GetPermissionLevel(player.FriendCode) >= 1)
+                if (Options.PlayerCanSetName.GetBool() || player.FriendCode.GetDevUser().IsDev || player.FriendCode.GetDevUser().NameCmd || TagManager.ReadPermission(player.FriendCode) >= 1)
                 {
                     if (GameStates.IsInGame)
                     {
@@ -2549,7 +2549,7 @@ internal class ChatCommands
             case "/айди":
             case "/编号":
             case "/玩家编号":
-                if ((Options.ApplyModeratorList.GetValue() == 0 || (!Utils.IsPlayerModerator(player.FriendCode) && TagManager.GetPermissionLevel(player.FriendCode) < 2))
+                if ((Options.ApplyModeratorList.GetValue() == 0 || (!Utils.IsPlayerModerator(player.FriendCode) && TagManager.ReadPermission(player.FriendCode) < 2))
                     && !Options.EnableVoteCommand.GetBool()) break;
 
                 string msgText = GetString("PlayerIdList");
@@ -2573,7 +2573,7 @@ internal class ChatCommands
                     break;
                 }
                 //checking if player is has necessary privellege or not
-                if (!Utils.IsPlayerModerator(player.FriendCode) && TagManager.GetPermissionLevel(player.FriendCode) < 2)
+                if (!Utils.IsPlayerModerator(player.FriendCode) && TagManager.ReadPermission(player.FriendCode) < 2)
                 {
                     Utils.SendMessage(GetString("midCommandNoAccess"), player.PlayerId);
                     break;
@@ -2601,7 +2601,7 @@ internal class ChatCommands
                 }
 
                 // Check if the player has the necessary privileges to use the command
-                if (!Utils.IsPlayerModerator(player.FriendCode) && TagManager.GetPermissionLevel(player.FriendCode) < 5)
+                if (!Utils.IsPlayerModerator(player.FriendCode) && TagManager.ReadPermission(player.FriendCode) < 5)
                 {
                     Utils.SendMessage(GetString("BanCommandNoAccess"), player.PlayerId);
                     break;
@@ -2638,7 +2638,7 @@ internal class ChatCommands
                 }
 
                 // Prevent moderators from baning other moderators
-                if (Utils.IsPlayerModerator(bannedPlayer.FriendCode) || TagManager.GetPermissionLevel(bannedPlayer.FriendCode) >= 2)
+                if (Utils.IsPlayerModerator(bannedPlayer.FriendCode) || TagManager.ReadPermission(bannedPlayer.FriendCode) >= 2)
                 {
                     Utils.SendMessage(GetString("BanCommandBanMod"), player.PlayerId);
                     break;
@@ -2678,7 +2678,7 @@ internal class ChatCommands
                     Utils.SendMessage(GetString("WarnCommandDisabled"), player.PlayerId);
                     break;
                 }
-                if (!Utils.IsPlayerModerator(player.FriendCode) && TagManager.GetPermissionLevel(player.FriendCode) < 2)
+                if (!Utils.IsPlayerModerator(player.FriendCode) && TagManager.ReadPermission(player.FriendCode) < 2)
                 {
                     Utils.SendMessage(GetString("WarnCommandNoAccess"), player.PlayerId);
                     break;
@@ -2703,7 +2703,7 @@ internal class ChatCommands
                 }
 
                 // Prevent moderators from warning other moderators
-                if (Utils.IsPlayerModerator(warnedPlayer.FriendCode) || TagManager.GetPermissionLevel(warnedPlayer.FriendCode) >= 2)
+                if (Utils.IsPlayerModerator(warnedPlayer.FriendCode) || TagManager.ReadPermission(warnedPlayer.FriendCode) >= 2)
                 {
                     Utils.SendMessage(GetString("WarnCommandWarnMod"), player.PlayerId);
                     break;
@@ -2748,7 +2748,7 @@ internal class ChatCommands
                 }
 
                 // Check if the player has the necessary privileges to use the command
-                if (!Utils.IsPlayerModerator(player.FriendCode) && TagManager.GetPermissionLevel(player.FriendCode) < 4)
+                if (!Utils.IsPlayerModerator(player.FriendCode) && TagManager.ReadPermission(player.FriendCode) < 4)
                 {
                     Utils.SendMessage(GetString("KickCommandNoAccess"), player.PlayerId);
                     break;
@@ -2775,7 +2775,7 @@ internal class ChatCommands
                 }
 
                 // Prevent moderators from kicking other moderators
-                if (Utils.IsPlayerModerator(kickedPlayer.FriendCode) || TagManager.GetPermissionLevel(kickedPlayer.FriendCode) >= 4)
+                if (Utils.IsPlayerModerator(kickedPlayer.FriendCode) || TagManager.ReadPermission(kickedPlayer.FriendCode) >= 4)
                 {
                     Utils.SendMessage(GetString("KickCommandKickMod"), player.PlayerId);
                     break;
@@ -3072,7 +3072,7 @@ internal class ChatCommands
                     }
                     else
                     {
-                        var modTitle = (Utils.IsPlayerModerator(player.FriendCode) || TagManager.GetPermissionLevel(player.FriendCode) >= 2) ? $"<color=#8bbee0>{GetString("MessageFromModerator")}" : $"<color=#ffff00>{GetString("MessageFromVIP")}";
+                        var modTitle = (Utils.IsPlayerModerator(player.FriendCode) || TagManager.ReadPermission(player.FriendCode) >= 2) ? $"<color=#8bbee0>{GetString("MessageFromModerator")}" : $"<color=#ffff00>{GetString("MessageFromVIP")}";
                         if (args.Length > 1)
                             Utils.SendMessage(args.Skip(1).Join(delimiter: " "), title: $"{modTitle} ~ <size=1.25>{player.GetRealName(clientData: true)}</size></color>");
                         //string moderatorName3 = player.GetRealName().ToString();
@@ -3326,7 +3326,7 @@ internal class ChatCommands
                 }
                 else
                 {
-                    if (Options.ApplyModeratorList.GetValue() == 0 || (!Utils.IsPlayerModerator(player.FriendCode) && TagManager.GetPermissionLevel(player.FriendCode) < 2))
+                    if (Options.ApplyModeratorList.GetValue() == 0 || (!Utils.IsPlayerModerator(player.FriendCode) && TagManager.ReadPermission(player.FriendCode) < 2))
                     {
                         Utils.SendMessage(GetString("Message.MeCommandNoPermission"), player.PlayerId);
                         break;
@@ -3369,7 +3369,7 @@ internal class ChatCommands
                     break;
                 }
 
-                if (!Utils.IsPlayerModerator(player.FriendCode) && TagManager.GetPermissionLevel(player.FriendCode) < 3)
+                if (!Utils.IsPlayerModerator(player.FriendCode) && TagManager.ReadPermission(player.FriendCode) < 3)
                 {
                     Utils.SendMessage(GetString("StartCommandNoAccess"), player.PlayerId);
 


### PR DESCRIPTION
Margs Tag Overhaul is epic but can get messy, so this PR should make it so friendCode#1234.txt file can be read in a folder  (Example like Friends folder, Staff folder, ABCDEF folder, etc), as long as its under the Tags directory. The only folders it shouldn't read are MOD_TAGS, VIP_TAGS, & SPONSOR_TAGS.