### PR TITLE
Fix broken teleport for modded clients + add delay for Mole

### DIFF
--- a/Modules/RPC.cs
+++ b/Modules/RPC.cs
@@ -693,7 +693,7 @@ internal class PlayerPhysicsRPCHandlerPatch
 
         if (!Main.MeetingIsStarted)
         {
-            __instance.myPlayer.walkingToVent = true;
+            //__instance.myPlayer.walkingToVent = true;
             VentSystemDeterioratePatch.ForceUpadate = true;
         }
 

--- a/Patches/RandomSpawnPatch.cs
+++ b/Patches/RandomSpawnPatch.cs
@@ -10,7 +10,7 @@ namespace TOHE;
 class RandomSpawn
 {
     [HarmonyPatch(typeof(CustomNetworkTransform), nameof(CustomNetworkTransform.SnapTo))]
-    [HarmonyPatch(new Type[] { typeof(Vector2), typeof(ushort) })]
+    [HarmonyPatch([typeof(Vector2), typeof(ushort)])]
     public class SnapToPatch
     {
         public static void Prefix(CustomNetworkTransform __instance, [HarmonyArgument(1)] ushort minSid)

--- a/Roles/Crewmate/Mole.cs
+++ b/Roles/Crewmate/Mole.cs
@@ -30,7 +30,7 @@ internal class Mole : RoleBase
     }
     public override void OnExitVent(PlayerControl pc, int ventId)
     {
-        float delay = Utils.GetActiveMapId() != 5 ? 0.1f : 0.4f;
+        float delay = 0.5f;
 
         _ = new LateTask(() =>
         {


### PR DESCRIPTION
`SnapTo` check `player.walkingToVent` but sometimes for modded players it is `true`, better remove code from `PlayerPhysics.HandleRpc`