### PR TITLE
Make Rift Portal and Firework visible for dead players

### DIFF
--- a/Roles/Impostor/Fireworker.cs
+++ b/Roles/Impostor/Fireworker.cs
@@ -124,7 +124,7 @@ internal class Fireworker : RoleBase
                 Logger.Info("One firework set up", "Fireworker");
 
                 FireworkerPosition[shapeshifterId].Add(shapeshifter.transform.position);
-                Fireworks.Add(new(shapeshifter.GetCustomPosition(), [.. Main.AllPlayerControls.Where(x => x.GetCountTypes() == CountTypes.Impostor).Select(x => x.PlayerId)], _state.PlayerId));
+                Fireworks.Add(new(shapeshifter.GetCustomPosition(), [.. Main.AllPlayerControls.Where(x => (x.GetCountTypes() == CountTypes.Impostor) || !x.IsAlive()).Select(x => x.PlayerId)], _state.PlayerId));
                 nowFireworkerCount[shapeshifterId]--;
                 state[shapeshifterId] = nowFireworkerCount[shapeshifterId] == 0
                     ? Main.AliveImpostorCount <= 1 ? FireworkerState.ReadyFire : FireworkerState.WaitTime

--- a/Roles/Impostor/RiftMaker.cs
+++ b/Roles/Impostor/RiftMaker.cs
@@ -147,7 +147,7 @@ internal class RiftMaker : RoleBase
             MarkedLocation.Remove(MarkedLocation.First(x => x.Key != Lastadded).Key);
         }
 
-        MarkedLocation.Add(shapeshifter.GetCustomPosition(), new(shapeshifter.GetCustomPosition(), [_state.PlayerId], _state.PlayerId));
+        MarkedLocation.Add(shapeshifter.GetCustomPosition(), new(shapeshifter.GetCustomPosition(), [.. Main.AllPlayerControls.Where(x => (x.PlayerId == _state.PlayerId) || !x.IsAlive()).Select(x => x.PlayerId)], _state.PlayerId));
         Lastadded = shapeshifter.GetCustomPosition();
         if (MarkedLocation.Count == 2) LastTP[shapeshifterId] = Utils.GetTimeStamp();
         shapeshifter.Notify(GetString("RiftCreated"));


### PR DESCRIPTION
Since the players are dead anyway, it would be better to show them the location of the abilities of some roles