### PR TITLE
Fixed recruitment issues with Jackal and ChiefOfPolice

### DIFF
--- a/Roles/Crewmate/ChiefOfPolice.cs
+++ b/Roles/Crewmate/ChiefOfPolice.cs
@@ -1,7 +1,9 @@
 using TOHE.Roles.Core;
+using TOHE.Roles.Impostor;
 using UnityEngine;
 using static TOHE.Options;
 using static TOHE.Translator;
+using static UnityEngine.GraphicsBuffer;
 
 namespace TOHE.Roles.Crewmate;
 
@@ -96,7 +98,11 @@ internal class ChiefOfPolice : RoleBase
         }
         else
         {
-            if (!CanRecruitCoven.GetBool() && target.IsPlayerCovenTeam() || !CanRecruitNeutral.GetBool() && target.IsPlayerNeutralTeam() || !CanRecruitImpostor.GetBool() && target.IsPlayerImpostorTeam())
+            if (!CanRecruitCoven.GetBool() && target.IsPlayerCovenTeam() || !CanRecruitNeutral.GetBool() && target.IsPlayerNeutralTeam() || !CanRecruitImpostor.GetBool() && target.IsPlayerImpostorTeam() || target.IsNeutralApocalypse())
+            {
+                suidice = true;
+            }
+            if (target.Is(CustomRoles.Zombie) || target.Is(CustomRoles.EvilMini)|| target.Is(CustomRoles.Loyal))
             {
                 suidice = true;
             }

--- a/Roles/Neutral/Jackal.cs
+++ b/Roles/Neutral/Jackal.cs
@@ -178,7 +178,7 @@ internal class Jackal : RoleBase
             Logger.Info("Jackal run out of recruits or Recruit disabled?", "Jackal");
             return true;
         }
-        if (!CanRecruitCoven.GetBool() && target.IsPlayerCovenTeam() || !CanRecruitNeutral.GetBool() && target.IsPlayerNeutralTeam() || !CanRecruitImpostor.GetBool() && target.IsPlayerImpostorTeam())
+        if (!CanRecruitCoven.GetBool() && target.IsPlayerCovenTeam() || !CanRecruitNeutral.GetBool() && target.IsPlayerNeutralTeam() || !CanRecruitImpostor.GetBool() && target.IsPlayerImpostorTeam() || target.IsNeutralApocalypse())
         {
             killer.Notify(Utils.ColorString(Utils.GetRoleColor(CustomRoles.Jackal), GetString("Jackal_RecruitFailed")));
             Logger.Info("Jackal can not recruit this target", "Jackal");


### PR DESCRIPTION
Jackal and ChiefOfPolice can't recruit Apocalypse Team right now.
Some special professions cannot be recruited by ChiefOfPolice.