### PR TITLE
Fix bug when RemoveIncompatibleAddOns counts self add-on as Incompatible

### DIFF
--- a/Modules/CustomRolesHelper.cs
+++ b/Modules/CustomRolesHelper.cs
@@ -456,7 +456,7 @@ public static class CustomRolesHelper
 
         return player.MainRole.IsCoven();
     }
-    public static bool CheckAddonConfilct(CustomRoles role, PlayerControl pc, bool checkLimitAddons = true)
+    public static bool CheckAddonConfilct(CustomRoles role, PlayerControl pc, bool checkLimitAddons = true, bool checkSelfAddOn = true)
     {
         // Only add-ons
         if (!role.IsAdditionRole() || pc == null) return false;
@@ -465,7 +465,7 @@ public static class CustomRolesHelper
             return false;
 
         // if player already has this addon
-        else if (pc.Is(role)) return false;
+        else if (checkSelfAddOn && pc.Is(role)) return false;
 
         // Checking Lovers and Romantics
         else if ((pc.Is(CustomRoles.RuthlessRomantic) || pc.Is(CustomRoles.Romantic) || pc.Is(CustomRoles.VengefulRomantic)) && role is CustomRoles.Lovers) return false;

--- a/Modules/ExtendedPlayerControl.cs
+++ b/Modules/ExtendedPlayerControl.cs
@@ -64,7 +64,7 @@ static class ExtendedPlayerControl
 
         foreach (var addon in roles)
         {
-            if (!CustomRolesHelper.CheckAddonConfilct(addon, player))
+            if (!CustomRolesHelper.CheckAddonConfilct(addon, player, checkSelfAddOn: false))
             {
                 Main.PlayerStates[player.PlayerId].RemoveSubRole(addon);
                 Logger.Info($"{player.GetNameWithRole()} had incompatible addon {addon.ToString()}, removing addon", $"{player.GetCustomRole().ToString()}");


### PR DESCRIPTION
Noticed this bug when testing the improved Task Manager

Add-on is assign to the player and them immediately removes it lol