### PR TITLE
Introduce timerLowLoad in FixedUpdate

### DIFF
--- a/Modules/CustomNetObject.cs
+++ b/Modules/CustomNetObject.cs
@@ -156,7 +156,7 @@ namespace TOHE.Modules
             writer.Recycle();
         }
 
-        protected virtual void OnFixedUpdate()
+        protected virtual void OnFixedUpdate(bool lowload, int timerLowLoad)
         {
             //
             // Need to respawn player every 20s because of 30s timeout
@@ -468,7 +468,7 @@ namespace TOHE.Modules
                 sender.SendMessage();
             }, 0.4f, "CNO_CreatePlayerControl_FixModdedCNO");
         }
-        public static void FixedUpdate() => AllObjects.ToArray().Do(x => x.OnFixedUpdate());
+        public static void FixedUpdate(bool lowload, int timerLowLoad) => AllObjects.ToArray().Do(x => x.OnFixedUpdate(lowload, timerLowLoad));
         public static void AfterMeetingTasks() => AllObjects.ToArray().Do(x => x.OnAfterMeetingTasks());
         public static CustomNetObject Get(int id) => AllObjects.FirstOrDefault(x => x.Id == id);
         public static void DespawnOnQuit(byte Playerid) => AllObjects.Where(x => x.OwnerId == Playerid).ToArray().Do(x => x.Despawn());
@@ -503,9 +503,9 @@ namespace TOHE.Modules
             CreateNetObject($"<size={Size}><line-height=72%><font=\"VCR SDF\"><br><#0000>███<#ff0000>█<#0000>███<br><#ff0000>█<#0000>█<#ff0000>███<#0000>█<#ff0000>█<br>█<#ff8000>██<#ffff00>█<#ff8000>██<#ffff00>█<br>██<#ff8000>█<#ffff00>█<#ff8000>█<#ffff00>██<br><#ff8000>█<#ffff80>██<#ffff00>█<#ffff80>██<#ff8000>█<br><#0000>█<#ff8000>█<#ffff80>███<#ff8000>█<#0000>█<br>██<#ff8000>███<#0000>██", position);
         }
 
-        protected override void OnFixedUpdate()
+        protected override void OnFixedUpdate(bool lowload, int timerLowLoad)
         {
-            base.OnFixedUpdate();
+            base.OnFixedUpdate(lowload, timerLowLoad);
 
             Timer += Time.deltaTime;
             if (Timer >= Duration / 5f && Frame == 0)

--- a/Modules/CustomNetObject.cs
+++ b/Modules/CustomNetObject.cs
@@ -313,6 +313,28 @@ namespace TOHE.Modules
                     }
                 }, 0.4f, "CNO_RespawnPlayerControl_FixModdedCNO");
                 PlayerControlTimer = 0f;
+
+                return;
+            }
+
+            // Host is the -2 owner of NT, dirty the NT and host will serialize it automatically.
+            var NT = playerControl.NetTransform;
+            
+            if (NT == null) return;
+            playerControl.Collider.enabled = false;
+            if (Position != NT.body.position)
+            {
+                Transform transform = NT.transform;
+                NT.body.position = Position;
+                transform.position = Position;
+                NT.body.velocity = Vector2.zero;
+                NT.lastSequenceId++;
+            }
+
+            if (NT.HasMoved())
+            {
+                NT.sendQueue.Enqueue(NT.body.position);
+                NT.SetDirtyBit(2U);
             }
         }
 
@@ -447,6 +469,7 @@ namespace TOHE.Modules
             }, 0.2f);
 
             Position = position;
+            playerControl.Collider.enabled = false;
             PlayerControlTimer = 0f;
             Sprite = sprite;
             ++MaxId;

--- a/Modules/RPC.cs
+++ b/Modules/RPC.cs
@@ -621,7 +621,11 @@ internal class RPCHandlerPatch
             case CustomRPC.FixModdedClientCNO:
                 var CNO = reader.ReadNetObject<PlayerControl>();
                 bool active = reader.ReadBoolean();
-                CNO?.transform.FindChild("Names").FindChild("NameText_TMP").gameObject.SetActive(active);
+                if (CNO != null)
+                {
+                    CNO.transform.FindChild("Names").FindChild("NameText_TMP").gameObject.SetActive(active);
+                    CNO.Collider.enabled = false;
+                }
                 break;
             case CustomRPC.SyncVultureBodyAmount:
                 Vulture.ReceiveBodyRPC(reader);

--- a/Patches/PlayerControlPatch.cs
+++ b/Patches/PlayerControlPatch.cs
@@ -1121,27 +1121,26 @@ class FixedUpdateInNormalGamePatch
 
         // The code is called once every 1 second (by one player)
         bool lowLoad = false;
-        if (Options.LowLoadMode.GetBool())
+
+        if (!BufferTime.TryGetValue(player.PlayerId, out var timerLowLoad))
         {
-            if (!BufferTime.TryGetValue(player.PlayerId, out var timerLowLoad))
-            {
-                BufferTime[player.PlayerId] = 30;
-                timerLowLoad = 30;
-            }
-
-            timerLowLoad--;
-
-            if (timerLowLoad > 0)
-            {
-                lowLoad = true;
-            }
-            else
-            {
-                timerLowLoad = 30;
-            }
-
-            BufferTime[player.PlayerId] = timerLowLoad;
+            BufferTime[player.PlayerId] = 30;
+            timerLowLoad = 30;
         }
+
+        timerLowLoad--;
+
+        if (timerLowLoad > 0)
+        {
+            if (Options.LowLoadMode.GetBool())
+                lowLoad = true;
+        }
+        else
+        {
+            timerLowLoad = 30;
+        }
+
+        BufferTime[player.PlayerId] = timerLowLoad;
 
         if (!lowLoad)
         {
@@ -1241,7 +1240,7 @@ class FixedUpdateInNormalGamePatch
                 if (localplayer)
                 {
                     if (CustomNetObject.AllObjects.Count > 0)
-                        CustomNetObject.FixedUpdate();
+                        CustomNetObject.FixedUpdate(lowLoad);
 
                     if (!lowLoad)
                         CovenManager.NecronomiconCheck();
@@ -1266,7 +1265,7 @@ class FixedUpdateInNormalGamePatch
 
             if (GameStates.IsInTask && !AntiBlackout.SkipTasks)
             {
-                CustomRoleManager.OnFixedUpdate(player, lowLoad, Utils.GetTimeStamp());
+                CustomRoleManager.OnFixedUpdate(player, lowLoad, Utils.GetTimeStamp(), timerLowLoad);
 
                 player.OnFixedAddonUpdate(lowLoad);
 

--- a/Patches/PlayerControlPatch.cs
+++ b/Patches/PlayerControlPatch.cs
@@ -1240,7 +1240,7 @@ class FixedUpdateInNormalGamePatch
                 if (localplayer)
                 {
                     if (CustomNetObject.AllObjects.Count > 0)
-                        CustomNetObject.FixedUpdate(lowLoad);
+                        CustomNetObject.FixedUpdate(lowLoad, timerLowLoad);
 
                     if (!lowLoad)
                         CovenManager.NecronomiconCheck();

--- a/Roles/(Ghosts)/Crewmate/Ghastly.cs
+++ b/Roles/(Ghosts)/Crewmate/Ghastly.cs
@@ -147,7 +147,7 @@ internal class Ghastly : RoleBase
     }
     private bool CheckConflicts(PlayerControl target) => target != null && (!GhastlyKillAllies.GetBool() || target.GetCountTypes() != _Player.GetCountTypes());
 
-    public override void OnFixedUpdate(PlayerControl player, bool lowLoad, long nowTime)
+    public override void OnFixedUpdate(PlayerControl player, bool lowLoad, long nowTime, int timerLowLoad)
     {
         if (lowLoad) return;
         var speed = Main.AllPlayerSpeed[player.PlayerId];

--- a/Roles/Core/CustomRoleManager.cs
+++ b/Roles/Core/CustomRoleManager.cs
@@ -433,9 +433,9 @@ public static class CustomRoleManager
     /// For interfering with other roles
     /// Registered with OnFixedUpdateOthers+= at initialization
     /// </summary>
-    public static void OnFixedUpdate(PlayerControl player, bool lowLoad, long nowTime)
+    public static void OnFixedUpdate(PlayerControl player, bool lowLoad, long nowTime,int timerLowLoad)
     {
-        player.GetRoleClass()?.OnFixedUpdate(player, lowLoad, nowTime);
+        player.GetRoleClass()?.OnFixedUpdate(player, lowLoad, nowTime, timerLowLoad);
 
         if (!OnFixedUpdateOthers.Any()) return;
         //Execute other viewpoint processing if any

--- a/Roles/Core/RoleBase.cs
+++ b/Roles/Core/RoleBase.cs
@@ -146,7 +146,7 @@ public abstract class RoleBase
     /// <summary>
     /// A local method to check conditions during gameplay, 30 times each second
     /// </summary>
-    public virtual void OnFixedUpdate(PlayerControl player, bool lowLoad, long nowTime)
+    public virtual void OnFixedUpdate(PlayerControl player, bool lowLoad, long nowTime, int timerLowLoad)
     { }
 
     /// <summary>

--- a/Roles/Coven/HexMaster.cs
+++ b/Roles/Coven/HexMaster.cs
@@ -202,7 +202,7 @@ internal class HexMaster : CovenManager
         LastHexedPlayer = byte.MaxValue;
         HasHexed = false;
     }
-    public override void OnFixedUpdate(PlayerControl player, bool lowLoad, long nowTime)
+    public override void OnFixedUpdate(PlayerControl player, bool lowLoad, long nowTime, int timerLowLoad)
     {
         if (!lowLoad && CurrentHexedPlayer == 254)
         {

--- a/Roles/Coven/Necromancer.cs
+++ b/Roles/Coven/Necromancer.cs
@@ -230,7 +230,7 @@ internal class Necromancer : CovenManager
             (role == CustomRoles.Mayor && Mayor.MayorRevealWhenDoneTasks.GetBool()) ||
             (role == CustomRoles.Executioner && Executioner.KnowTargetRole.GetBool());
     }
-    public override void OnFixedUpdate(PlayerControl player, bool lowLoad, long nowTime)
+    public override void OnFixedUpdate(PlayerControl player, bool lowLoad, long nowTime, int timerLowLoad)
     {
         if (AbilityTimer < AbilityCooldown.GetFloat())
         {

--- a/Roles/Coven/Poisoner.cs
+++ b/Roles/Coven/Poisoner.cs
@@ -93,7 +93,7 @@ internal class Poisoner : CovenManager
         killer.SetKillCooldown();
     }
 
-    public override void OnFixedUpdate(PlayerControl poisoner, bool lowLoad, long nowTime)
+    public override void OnFixedUpdate(PlayerControl poisoner, bool lowLoad, long nowTime, int timerLowLoad)
     {
         var poisonerID = poisoner.PlayerId;
         List<byte> targetList = new(PoisonedPlayers.Where(b => b.Value.PoisonerId == poisonerID).Select(b => b.Key));

--- a/Roles/Coven/Sacrifist.cs
+++ b/Roles/Coven/Sacrifist.cs
@@ -316,7 +316,7 @@ internal class Sacrifist : CovenManager
     {
         return GetString("SacrifistDebuffCooldown") + ": " + string.Format("{0:f0}", debuffTimer) + "s / " + string.Format("{0:f0}", maxDebuffTimer) + "s";
     }
-    public override void OnFixedUpdate(PlayerControl player, bool lowLoad, long nowTime)
+    public override void OnFixedUpdate(PlayerControl player, bool lowLoad, long nowTime, int timerLowLoad)
     {
         if (debuffTimer < maxDebuffTimer)
         {

--- a/Roles/Crewmate/Addict.cs
+++ b/Roles/Crewmate/Addict.cs
@@ -77,7 +77,7 @@ internal class Addict : RoleBase
             Main.AllPlayerSpeed[player] = DefaultSpeed;
         }
     }
-    public override void OnFixedUpdate(PlayerControl player, bool lowLoad, long nowTime)
+    public override void OnFixedUpdate(PlayerControl player, bool lowLoad, long nowTime, int timerLowLoad)
     {
         if (!player.IsAlive() || !SuicideTimer.TryGetValue(player.PlayerId, out var timer)) return;
 

--- a/Roles/Crewmate/Alchemist.cs
+++ b/Roles/Crewmate/Alchemist.cs
@@ -214,7 +214,7 @@ internal class Alchemist : RoleBase
             }
         }
     }
-    public override void OnFixedUpdate(PlayerControl player, bool lowLoad, long nowTime)
+    public override void OnFixedUpdate(PlayerControl player, bool lowLoad, long nowTime, int timerLowLoad)
     {
         if (lowLoad || !IsInvis(player.PlayerId)) return;
 

--- a/Roles/Crewmate/Benefactor.cs
+++ b/Roles/Crewmate/Benefactor.cs
@@ -200,7 +200,7 @@ internal class Benefactor : RoleBase
         return true;
     }
 
-    public override void OnFixedUpdate(PlayerControl player, bool lowLoad, long nowTime)
+    public override void OnFixedUpdate(PlayerControl player, bool lowLoad, long nowTime, int timerLowLoad)
     {
         if (lowLoad) return;
         foreach (var shieldedData in shieldedPlayers.Where(x => x.Value + ShieldDuration.GetInt() < nowTime).ToArray())

--- a/Roles/Crewmate/Chameleon.cs
+++ b/Roles/Crewmate/Chameleon.cs
@@ -139,7 +139,7 @@ internal class Chameleon : RoleBase
         }
         return true;
     }
-    public override void OnFixedUpdate(PlayerControl player, bool lowLoad, long nowTime)
+    public override void OnFixedUpdate(PlayerControl player, bool lowLoad, long nowTime, int timerLowLoad)
     {
         if (lowLoad) return;
         var playerId = player.PlayerId;

--- a/Roles/Crewmate/Grenadier.cs
+++ b/Roles/Crewmate/Grenadier.cs
@@ -140,7 +140,7 @@ internal class Grenadier : RoleBase
 
     public static bool stopGrenadierSkill = false;
     public static bool stopMadGrenadierSkill = false;
-    public override void OnFixedUpdate(PlayerControl player, bool lowLoad, long nowTime)
+    public override void OnFixedUpdate(PlayerControl player, bool lowLoad, long nowTime, int timerLowLoad)
     {
         if (lowLoad) return;
         if (!GrenadierBlinding.ContainsKey(player.PlayerId) && !MadGrenadierBlinding.ContainsKey(player.PlayerId)) return;

--- a/Roles/Crewmate/Lighter.cs
+++ b/Roles/Crewmate/Lighter.cs
@@ -55,7 +55,7 @@ internal class Lighter : RoleBase
     {
         Timer = 0;
     }
-    public override void OnFixedUpdate(PlayerControl player, bool lowLoad, long nowTime)
+    public override void OnFixedUpdate(PlayerControl player, bool lowLoad, long nowTime, int timerLowLoad)
     {
         if (!lowLoad && Timer != 0 && Timer + LighterSkillDuration.GetInt() < nowTime)
         {

--- a/Roles/Crewmate/Overseer.cs
+++ b/Roles/Crewmate/Overseer.cs
@@ -184,7 +184,7 @@ internal class Overseer : RoleBase
         }
         return false;
     }
-    public override void OnFixedUpdate(PlayerControl player, bool lowLoad, long nowTime)
+    public override void OnFixedUpdate(PlayerControl player, bool lowLoad, long nowTime, int timerLowLoad)
     {
         if (!OverseerTimer.TryGetValue(player.PlayerId, out var data)) return;
 

--- a/Roles/Crewmate/Spy.cs
+++ b/Roles/Crewmate/Spy.cs
@@ -111,7 +111,7 @@ internal class Spy : RoleBase
     public override bool OnCheckMurderAsTarget(PlayerControl killer, PlayerControl target)
         => OnKillAttempt(killer, target);
 
-    public override void OnFixedUpdate(PlayerControl player, bool lowLoad, long nowTime)
+    public override void OnFixedUpdate(PlayerControl player, bool lowLoad, long nowTime, int timerLowLoad)
     {
         if (lowLoad || !SpyRedNameList.Any()) return;
 

--- a/Roles/Crewmate/Telecommunication.cs
+++ b/Roles/Crewmate/Telecommunication.cs
@@ -46,7 +46,7 @@ internal class Telecommunication : RoleBase
         AURoleOptions.EngineerCooldown = 1f;
         AURoleOptions.EngineerInVentMaxTime = 0f;
     }
-    public override void OnFixedUpdate(PlayerControl player, bool lowLoad, long nowTime)
+    public override void OnFixedUpdate(PlayerControl player, bool lowLoad, long nowTime, int timerLowLoad)
     {
         if (lowLoad) return;
         Count--; if (Count > 0) return; Count = 5;

--- a/Roles/Crewmate/TimeMaster.cs
+++ b/Roles/Crewmate/TimeMaster.cs
@@ -71,7 +71,7 @@ internal class TimeMaster : RoleBase
         hud.ReportButton.OverrideText(GetString("ReportButtonText"));
         hud.AbilityButton.buttonLabelText.text = GetString("TimeMasterVentButtonText");
     }
-    public override void OnFixedUpdate(PlayerControl player, bool lowLoad, long nowTime)
+    public override void OnFixedUpdate(PlayerControl player, bool lowLoad, long nowTime, int timerLowLoad)
     {
         if (!lowLoad && TimeMasterInProtect.TryGetValue(player.PlayerId, out var vtime) && vtime + TimeMasterSkillDuration.GetInt() < nowTime)
         {

--- a/Roles/Crewmate/Veteran.cs
+++ b/Roles/Crewmate/Veteran.cs
@@ -97,7 +97,7 @@ internal class Veteran : RoleBase
             }
         return true;
     }
-    public override void OnFixedUpdate(PlayerControl player, bool lowLoad, long nowTime)
+    public override void OnFixedUpdate(PlayerControl player, bool lowLoad, long nowTime, int timerLowLoad)
     {
         if (!lowLoad && VeteranInProtect.TryGetValue(player.PlayerId, out var vtime) && vtime + VeteranSkillDuration.GetInt() < nowTime)
         {

--- a/Roles/Impostor/AbyssBringer.cs
+++ b/Roles/Impostor/AbyssBringer.cs
@@ -102,7 +102,7 @@ internal class AbyssBringer : RoleBase
     }
     public override void SetAbilityButtonText(HudManager hud, byte id) => hud.AbilityButton.OverrideText(Translator.GetString("AbyssbringerButtonText"));
     // public override Sprite GetAbilityButtonSprite(PlayerControl player, bool shapeshifting) => CustomButton.Get("Black Hole");
-    public override void OnFixedUpdate(PlayerControl pc, bool lowLoad, long nowTime)
+    public override void OnFixedUpdate(PlayerControl pc, bool lowLoad, long nowTime, int timerLowLoad)
     {
         var abyssbringer = _Player;
 

--- a/Roles/Impostor/AbyssBringer.cs
+++ b/Roles/Impostor/AbyssBringer.cs
@@ -134,8 +134,8 @@ internal class AbyssBringer : RoleBase
                 {
                     var direction = (pos - blackHole.Position).normalized;
                     var newPosition = blackHole.Position + direction * BlackHoleMoveSpeed.GetFloat() * Time.fixedDeltaTime;
-                    blackHole.NetObject.TP(newPosition);
                     blackHole.Position = newPosition;
+                    blackHole.NetObject.Position = newPosition;
                 }
 
                 if (Vector2.Distance(pos, blackHole.Position) <= BlackHoleRadius.GetFloat())

--- a/Roles/Impostor/AntiAdminer.cs
+++ b/Roles/Impostor/AntiAdminer.cs
@@ -41,7 +41,7 @@ internal class AntiAdminer : RoleBase
     }
 
     private static int Count = 0;
-    public override void OnFixedUpdate(PlayerControl player, bool lowLoad, long nowTime)
+    public override void OnFixedUpdate(PlayerControl player, bool lowLoad, long nowTime, int timerLowLoad)
     {
         if (lowLoad) return;
         Count--; if (Count > 0) return; Count = 3;

--- a/Roles/Impostor/BountyHunter.cs
+++ b/Roles/Impostor/BountyHunter.cs
@@ -105,7 +105,7 @@ internal class BountyHunter : RoleBase
         return true;
     }
     public override void OnReportDeadBody(PlayerControl reporter, NetworkedPlayerInfo target) => ChangeTimer.Clear();
-    public override void OnFixedUpdate(PlayerControl player, bool lowLoad, long nowTime)
+    public override void OnFixedUpdate(PlayerControl player, bool lowLoad, long nowTime, int timerLowLoad)
     {
         if (!ChangeTimer.TryGetValue(player.PlayerId, out var timer)) return;
 

--- a/Roles/Impostor/Chronomancer.cs
+++ b/Roles/Impostor/Chronomancer.cs
@@ -136,7 +136,7 @@ internal class Chronomancer : RoleBase
         killer.SetKillCooldown();
         return true;
     }
-    public override void OnFixedUpdate(PlayerControl player, bool lowLoad, long nowTime)
+    public override void OnFixedUpdate(PlayerControl player, bool lowLoad, long nowTime, int timerLowLoad)
     {
         if (!Main.IntroDestroyed) return;
 

--- a/Roles/Impostor/Deathpact.cs
+++ b/Roles/Impostor/Deathpact.cs
@@ -151,7 +151,7 @@ internal class Deathpact : RoleBase
         }
     }
 
-    public override void OnFixedUpdate(PlayerControl player, bool lowLoad, long nowTime)
+    public override void OnFixedUpdate(PlayerControl player, bool lowLoad, long nowTime, int timerLowLoad)
     {
         if (lowLoad || !ActiveDeathpacts.Contains(player.PlayerId)) return;
         if (CheckCancelDeathpact(player)) return;

--- a/Roles/Impostor/DollMaster.cs
+++ b/Roles/Impostor/DollMaster.cs
@@ -80,7 +80,7 @@ internal class DollMaster : RoleBase
         opt.SetFloat(FloatOptionNames.ImpostorLightMod, 0f * 0);
     }
 
-    public override void OnFixedUpdate(PlayerControl player, bool lowLoad, long nowTime)
+    public override void OnFixedUpdate(PlayerControl player, bool lowLoad, long nowTime, int timerLowLoad)
     {
         if (lowLoad) return;
         if (controllingTarget != null && DollMasterTarget != null)

--- a/Roles/Impostor/DoubleAgent.cs
+++ b/Roles/Impostor/DoubleAgent.cs
@@ -192,7 +192,7 @@ internal class DoubleAgent : RoleBase
     }
 
     // Set timer on Double Agent for Non-Modded Clients.
-    public override void OnFixedUpdate(PlayerControl player, bool lowLoad, long nowTime)
+    public override void OnFixedUpdate(PlayerControl player, bool lowLoad, long nowTime, int timerLowLoad)
     {
         if (lowLoad) return;
 

--- a/Roles/Impostor/EvilHacker.cs
+++ b/Roles/Impostor/EvilHacker.cs
@@ -183,7 +183,7 @@ internal class EvilHacker : RoleBase
             Utils.NotifyRoles(SpecifySeer: evilHackerPlayer);
         }
     }
-    public override void OnFixedUpdate(PlayerControl player, bool lowLoad, long nowTime)
+    public override void OnFixedUpdate(PlayerControl player, bool lowLoad, long nowTime, int timerLowLoad)
     {
         if (lowLoad || !activeNotifies.Any())
         {

--- a/Roles/Impostor/Lightning.cs
+++ b/Roles/Impostor/Lightning.cs
@@ -110,7 +110,7 @@ internal class Lightning : RoleBase
         RealKiller.TryAdd(killer.PlayerId, target);
         StartConvertCountDown(target, killer);
     }
-    public override void OnFixedUpdate(PlayerControl player, bool lowLoad, long nowTime)
+    public override void OnFixedUpdate(PlayerControl player, bool lowLoad, long nowTime, int timerLowLoad)
     {
         if (lowLoad || !GhostPlayer.Any()) return;
 

--- a/Roles/Impostor/Mastermind.cs
+++ b/Roles/Impostor/Mastermind.cs
@@ -77,7 +77,7 @@ internal class Mastermind : RoleBase
         });
     }
 
-    public override void OnFixedUpdate(PlayerControl mastermind, bool lowLoad, long nowTime)
+    public override void OnFixedUpdate(PlayerControl mastermind, bool lowLoad, long nowTime, int timerLowLoad)
     {
         if (lowLoad) return;
         if (ManipulatedPlayers.Count == 0 && ManipulateDelays.Count == 0) return;

--- a/Roles/Impostor/Mercenary.cs
+++ b/Roles/Impostor/Mercenary.cs
@@ -70,7 +70,7 @@ internal class Mercenary : RoleBase
 
     public static void ClearSuicideTimer() => SuicideTimer.Clear();
 
-    public override void OnFixedUpdate(PlayerControl player, bool lowLoad, long nowTime)
+    public override void OnFixedUpdate(PlayerControl player, bool lowLoad, long nowTime, int timerLowLoad)
     {
         if (!HasKilled(player))
         {

--- a/Roles/Impostor/Penguin.cs
+++ b/Roles/Impostor/Penguin.cs
@@ -246,7 +246,7 @@ internal class Penguin : RoleBase
             // SnapToRPC does not work for players on top of the ladder, and only the host behaves differently, so teleporting is not done uniformly.
             else if (!AbductVictim.MyPhysics.Animations.IsPlayingAnyLadderAnimation())
             {
-                if (timerLowLoad % 3 != 0) return;
+                if (Main.CurrentServerIsVanilla && timerLowLoad % 3 != 0) return;
 
                 var position = penguin.transform.position;
                 if (!penguin.IsHost())

--- a/Roles/Impostor/Penguin.cs
+++ b/Roles/Impostor/Penguin.cs
@@ -193,7 +193,7 @@ internal class Penguin : RoleBase
         }
         return false;
     }
-    public override void OnFixedUpdate(PlayerControl penguin, bool lowLoad, long nowTime)
+    public override void OnFixedUpdate(PlayerControl penguin, bool lowLoad, long nowTime, int timerLowLoad)
     {
         if (!stopCount)
             AbductTimer -= Time.fixedDeltaTime;

--- a/Roles/Impostor/Penguin.cs
+++ b/Roles/Impostor/Penguin.cs
@@ -246,6 +246,8 @@ internal class Penguin : RoleBase
             // SnapToRPC does not work for players on top of the ladder, and only the host behaves differently, so teleporting is not done uniformly.
             else if (!AbductVictim.MyPhysics.Animations.IsPlayingAnyLadderAnimation())
             {
+                if (timerLowLoad % 3 != 0) return;
+
                 var position = penguin.transform.position;
                 if (!penguin.IsHost())
                 {

--- a/Roles/Impostor/RiftMaker.cs
+++ b/Roles/Impostor/RiftMaker.cs
@@ -174,7 +174,7 @@ internal class RiftMaker : RoleBase
         }, 0.5f, "RiftMakerOnVent");
     }
 
-    public override void OnFixedUpdate(PlayerControl player, bool lowLoad, long nowTime)
+    public override void OnFixedUpdate(PlayerControl player, bool lowLoad, long nowTime, int timerLowLoad)
     {
         if (player == null) return;
         if (Pelican.IsEaten(player.PlayerId) || !player.IsAlive()) return;

--- a/Roles/Impostor/Stealth.cs
+++ b/Roles/Impostor/Stealth.cs
@@ -79,7 +79,7 @@ internal class Stealth : RoleBase
             player.MarkDirtySettings();
         }
     }
-    public override void OnFixedUpdate(PlayerControl player, bool lowLoad, long nowTime)
+    public override void OnFixedUpdate(PlayerControl player, bool lowLoad, long nowTime, int timerLowLoad)
     {
         // when you're darkening someone
         if (darkenedPlayers == null) return;

--- a/Roles/Impostor/Swooper.cs
+++ b/Roles/Impostor/Swooper.cs
@@ -116,7 +116,7 @@ internal class Swooper : RoleBase
         }, 0.8f, "Swooper Vent");
     }
 
-    public override void OnFixedUpdate(PlayerControl player, bool lowLoad, long nowTime)
+    public override void OnFixedUpdate(PlayerControl player, bool lowLoad, long nowTime, int timerLowLoad)
     {
         if (lowLoad) return;
         var playerId = player.PlayerId;

--- a/Roles/Impostor/Vampire.cs
+++ b/Roles/Impostor/Vampire.cs
@@ -92,7 +92,7 @@ internal class Vampire : RoleBase
         return false;
     }
 
-    public override void OnFixedUpdate(PlayerControl vampire, bool lowLoad, long nowTime)
+    public override void OnFixedUpdate(PlayerControl vampire, bool lowLoad, long nowTime, int timerLowLoad)
     {
         var vampireId = vampire.PlayerId;
         List<byte> targetList = new(BittenPlayers.Where(b => b.Value.VampireId == vampireId).Select(b => b.Key));

--- a/Roles/Impostor/Warlock.cs
+++ b/Roles/Impostor/Warlock.cs
@@ -141,7 +141,7 @@ internal class Warlock : RoleBase
         }
     }
 
-    public override void OnFixedUpdate(PlayerControl player, bool lowLoad, long nowTime)
+    public override void OnFixedUpdate(PlayerControl player, bool lowLoad, long nowTime, int timerLowLoad)
     {
         if (WarlockTimer.TryGetValue(player.PlayerId, out var warlockTimer))
         {

--- a/Roles/Impostor/Wildling.cs
+++ b/Roles/Impostor/Wildling.cs
@@ -81,7 +81,7 @@ internal class Wildling : RoleBase
 
         killer.Notify(Translator.GetString("BKInProtect"));
     }
-    public override void OnFixedUpdate(PlayerControl player, bool lowLoad, long nowTime)
+    public override void OnFixedUpdate(PlayerControl player, bool lowLoad, long nowTime, int timerLowLoad)
     {
         if (!lowLoad && TimeStamp != 0 && TimeStamp < nowTime)
         {

--- a/Roles/Impostor/YinYanger.cs
+++ b/Roles/Impostor/YinYanger.cs
@@ -84,7 +84,7 @@ internal class YinYanger : RoleBase
 
         return seen.PlayerId == yin?.PlayerId || seen.PlayerId == yang?.PlayerId ? ColorString(col, "☯") : string.Empty;
     }
-    public override void OnFixedUpdate(PlayerControl player, bool lowLoad, long nowTime)
+    public override void OnFixedUpdate(PlayerControl player, bool lowLoad, long nowTime, int timerLowLoad)
     {
         if (lowLoad) return;
         var (yin, yang) = Yanged[player.PlayerId];

--- a/Roles/Neutral/Agitater.cs
+++ b/Roles/Neutral/Agitater.cs
@@ -63,7 +63,7 @@ internal class Agitater : RoleBase
         LastBombedPlayer = byte.MaxValue;
         AgitaterHasBombed = false;
     }
-    public override void OnFixedUpdate(PlayerControl player, bool lowLoad, long nowTime)
+    public override void OnFixedUpdate(PlayerControl player, bool lowLoad, long nowTime, int timerLowLoad)
     {
         if (!lowLoad && CurrentBombedPlayer == 254)
         {

--- a/Roles/Neutral/Arsonist.cs
+++ b/Roles/Neutral/Arsonist.cs
@@ -125,7 +125,7 @@ internal class Arsonist : RoleBase
         _Player.RpcSetVentInteraction();
         _ = new LateTask(() => { NotifyRoles(SpecifySeer: _Player, ForceLoop: false); }, 1f, $"Update name for Arsonist {_Player?.PlayerId}", shoudLog: false);
     }
-    public override void OnFixedUpdate(PlayerControl player, bool lowLoad, long nowTime)
+    public override void OnFixedUpdate(PlayerControl player, bool lowLoad, long nowTime, int timerLowLoad)
     {
         if (ArsonistTimer.TryGetValue(player.PlayerId, out var arsonistTimerData))
         {

--- a/Roles/Neutral/Baker.cs
+++ b/Roles/Neutral/Baker.cs
@@ -309,7 +309,7 @@ internal class Baker : RoleBase
         if (_Player)
             BarrierList[_Player.PlayerId].Clear();
     }
-    public override void OnFixedUpdate(PlayerControl player, bool lowLoad, long nowTime)
+    public override void OnFixedUpdate(PlayerControl player, bool lowLoad, long nowTime, int timerLowLoad)
     {
         if (lowLoad || player.Is(CustomRoles.Famine)) return;
 

--- a/Roles/Neutral/BloodKnight.cs
+++ b/Roles/Neutral/BloodKnight.cs
@@ -82,7 +82,7 @@ internal class BloodKnight : RoleBase
     public override bool CanUseImpostorVentButton(PlayerControl pc) => CanVent.GetBool();
     public override bool CanUseKillButton(PlayerControl pc) => true;
 
-    public override void OnFixedUpdate(PlayerControl player, bool lowLoad, long nowTime)
+    public override void OnFixedUpdate(PlayerControl player, bool lowLoad, long nowTime, int timerLowLoad)
     {
         if (!lowLoad && TimeStamp < nowTime && TimeStamp != 0)
         {

--- a/Roles/Neutral/Glitch.cs
+++ b/Roles/Neutral/Glitch.cs
@@ -133,7 +133,7 @@ internal class Glitch : RoleBase
         }
         else return false;
     }
-    public override void OnFixedUpdate(PlayerControl player, bool lowLoad, long nowTime)
+    public override void OnFixedUpdate(PlayerControl player, bool lowLoad, long nowTime, int timerLowLoad)
     {
         if (lowLoad || !Main.IntroDestroyed) return;
 

--- a/Roles/Neutral/Pelican.cs
+++ b/Roles/Neutral/Pelican.cs
@@ -264,7 +264,7 @@ internal class Pelican : RoleBase
         GameEndCheckerForNormal.ShouldNotCheck = false;
     }
 
-    public override void OnFixedUpdate(PlayerControl player, bool lowLoad, long nowTime)
+    public override void OnFixedUpdate(PlayerControl player, bool lowLoad, long nowTime, int timerLowLoad)
     {
         if (lowLoad) return;
 

--- a/Roles/Neutral/Seeker.cs
+++ b/Roles/Neutral/Seeker.cs
@@ -108,7 +108,7 @@ internal class Seeker : RoleBase
         Main.AllPlayerSpeed[_state.PlayerId] = DefaultSpeed;
     }
 
-    public override void OnFixedUpdate(PlayerControl player, bool lowLoad, long nowTime)
+    public override void OnFixedUpdate(PlayerControl player, bool lowLoad, long nowTime, int timerLowLoad)
     {
         if (lowLoad) return;
 

--- a/Roles/Neutral/Solsticer.cs
+++ b/Roles/Neutral/Solsticer.cs
@@ -166,7 +166,7 @@ internal class Solsticer : RoleBase
         MurderMessage = "";
         patched = false;
     }
-    public override void OnFixedUpdate(PlayerControl player, bool lowLoad, long nowTime)
+    public override void OnFixedUpdate(PlayerControl player, bool lowLoad, long nowTime, int timerLowLoad)
     {
         if (lowLoad) return;
         if (patched)

--- a/Roles/Neutral/Vulture.cs
+++ b/Roles/Neutral/Vulture.cs
@@ -100,7 +100,7 @@ internal class Vulture : RoleBase
         else
             BodyReportCount[playerId] = body;
     }
-    public override void OnFixedUpdate(PlayerControl player, bool lowLoad, long nowTime)
+    public override void OnFixedUpdate(PlayerControl player, bool lowLoad, long nowTime, int timerLowLoad)
     {
         if (lowLoad || !player.IsAlive()) return;
 

--- a/Roles/Neutral/Wraith.cs
+++ b/Roles/Neutral/Wraith.cs
@@ -101,7 +101,7 @@ internal class Wraith : RoleBase
             SendRPC(wraith);
         }
     }
-    public override void OnFixedUpdate(PlayerControl player, bool lowLoad, long nowTime)
+    public override void OnFixedUpdate(PlayerControl player, bool lowLoad, long nowTime, int timerLowLoad)
     {
         if (lowLoad) return;
 


### PR DESCRIPTION
An attempt to bypass InnerSloth Rate Limit anti-mod

force set timerlowload per second

use serialize instead of snapto in Custom net object 100% bypass rate limit ac

send penguin snapto calls 10 times per second with timerlowload