### PR TITLE
Global Bypass RateLimit

### DIFF
--- a/Modules/ChatManager.cs
+++ b/Modules/ChatManager.cs
@@ -164,7 +164,7 @@ namespace TOHE.Modules.ChatManager
             var title = "<color=#aaaaff>" + GetString("DefaultSystemMessageTitle") + "</color>";
             var name = firstAlivePlayer?.Data?.PlayerName ?? "Error";
 
-            var writer = CustomRpcSender.Create("EzHacked_QuickChatSpamExploit", SendOption.Reliable);
+            var writer = CustomRpcSender.Create("EzHacked_QuickChatSpamExploit", ExtendedPlayerControl.RpcSendOption);
             writer.AutoStartRpc(firstAlivePlayer.NetId, (byte)RpcCalls.SetName);
             writer.Write(firstAlivePlayer.Data.NetId);
             writer.Write(title);

--- a/Modules/ExtendedPlayerControl.cs
+++ b/Modules/ExtendedPlayerControl.cs
@@ -401,7 +401,7 @@ static class ExtendedPlayerControl
         var clientId = seer.GetClientId();
         if (clientId == -1) return;
 
-        MessageWriter writer = AmongUsClient.Instance.StartRpcImmediately(player.NetId, (byte)RpcCalls.SetName, SendOption.Reliable, clientId);
+        MessageWriter writer = AmongUsClient.Instance.StartRpcImmediately(player.NetId, (byte)RpcCalls.SetName, Main.CurrentServerIsVanilla ? SendOption.None : SendOption.Reliable, clientId);
         writer.Write(seer.Data.NetId);
         writer.Write(name);
         AmongUsClient.Instance.FinishRpcImmediately(writer);
@@ -870,8 +870,35 @@ static class ExtendedPlayerControl
             return;
         }
 
+        var sendOption = SendOption.Reliable;
+
+        if (Main.CurrentServerIsVanilla)
+        {
+            if (!FixedUpdateInNormalGamePatch.BufferTime.TryGetValue(player.PlayerId, out var bufferTime))
+            {
+                Logger.Error($"Canceled RpcTeleport bcz bufferTime is null.", "RpcTeleport");
+                return;
+            }
+
+            if (!FixedUpdateInNormalGamePatch.TeleportBuffer.TryGetValue(player.PlayerId, out var teleportBuffer))
+            {
+                FixedUpdateInNormalGamePatch.TeleportBuffer[player.PlayerId] = bufferTime;
+            }
+            else
+            {
+                if (bufferTime >= teleportBuffer + 6)
+                {
+                    FixedUpdateInNormalGamePatch.TeleportBuffer[player.PlayerId] = bufferTime;
+                }
+                else
+                {
+                    sendOption = SendOption.None;
+                }
+            }
+        }
+
         ushort newSid = (ushort)(netTransform.lastSequenceId + 8);
-        MessageWriter messageWriter = AmongUsClient.Instance.StartRpcImmediately(netTransform.NetId, (byte)RpcCalls.SnapTo, SendOption.Reliable);
+        MessageWriter messageWriter = AmongUsClient.Instance.StartRpcImmediately(netTransform.NetId, (byte)RpcCalls.SnapTo, sendOption);
         NetHelpers.WriteVector2(position, messageWriter);
         messageWriter.Write(newSid);
         AmongUsClient.Instance.FinishRpcImmediately(messageWriter);

--- a/Modules/ExtendedPlayerControl.cs
+++ b/Modules/ExtendedPlayerControl.cs
@@ -401,7 +401,7 @@ static class ExtendedPlayerControl
         var clientId = seer.GetClientId();
         if (clientId == -1) return;
 
-        MessageWriter writer = AmongUsClient.Instance.StartRpcImmediately(player.NetId, (byte)RpcCalls.SetName, Main.CurrentServerIsVanilla ? SendOption.None : SendOption.Reliable, clientId);
+        MessageWriter writer = AmongUsClient.Instance.StartRpcImmediately(player.NetId, (byte)RpcCalls.SetName, SendOption.Reliable, clientId);
         writer.Write(seer.Data.NetId);
         writer.Write(name);
         AmongUsClient.Instance.FinishRpcImmediately(writer);
@@ -870,35 +870,8 @@ static class ExtendedPlayerControl
             return;
         }
 
-        var sendOption = SendOption.Reliable;
-
-        if (Main.CurrentServerIsVanilla)
-        {
-            if (!FixedUpdateInNormalGamePatch.BufferTime.TryGetValue(player.PlayerId, out var bufferTime))
-            {
-                Logger.Error($"Canceled RpcTeleport bcz bufferTime is null.", "RpcTeleport");
-                return;
-            }
-
-            if (!FixedUpdateInNormalGamePatch.TeleportBuffer.TryGetValue(player.PlayerId, out var teleportBuffer))
-            {
-                FixedUpdateInNormalGamePatch.TeleportBuffer[player.PlayerId] = bufferTime;
-            }
-            else
-            {
-                if (bufferTime >= teleportBuffer + 6)
-                {
-                    FixedUpdateInNormalGamePatch.TeleportBuffer[player.PlayerId] = bufferTime;
-                }
-                else
-                {
-                    sendOption = SendOption.None;
-                }
-            }
-        }
-
         ushort newSid = (ushort)(netTransform.lastSequenceId + 8);
-        MessageWriter messageWriter = AmongUsClient.Instance.StartRpcImmediately(netTransform.NetId, (byte)RpcCalls.SnapTo, sendOption);
+        MessageWriter messageWriter = AmongUsClient.Instance.StartRpcImmediately(netTransform.NetId, (byte)RpcCalls.SnapTo, SendOption.Reliable);
         NetHelpers.WriteVector2(position, messageWriter);
         messageWriter.Write(newSid);
         AmongUsClient.Instance.FinishRpcImmediately(messageWriter);

--- a/Modules/ExtendedPlayerControl.cs
+++ b/Modules/ExtendedPlayerControl.cs
@@ -785,7 +785,7 @@ static class ExtendedPlayerControl
     }
     public static void RpcDesyncUpdateSystem(this PlayerControl target, SystemTypes systemType, int amount)
     {
-        var messageWriter = AmongUsClient.Instance.StartRpcImmediately(ShipStatus.Instance.NetId, (byte)RpcCalls.UpdateSystem, SendOption.Reliable, target.GetClientId());
+        var messageWriter = AmongUsClient.Instance.StartRpcImmediately(ShipStatus.Instance.NetId, (byte)RpcCalls.UpdateSystem, RpcSendOption, target.GetClientId());
         messageWriter.Write((byte)systemType);
         messageWriter.WriteNetObject(target);
         messageWriter.Write((byte)amount);

--- a/Modules/ExtendedPlayerControl.cs
+++ b/Modules/ExtendedPlayerControl.cs
@@ -83,7 +83,7 @@ static class ExtendedPlayerControl
             player.SetRole(role, true);
             return;
         }
-        MessageWriter writer = AmongUsClient.Instance.StartRpcImmediately(player.NetId, (byte)RpcCalls.SetRole, SendOption.Reliable, clientId);
+        MessageWriter writer = AmongUsClient.Instance.StartRpcImmediately(player.NetId, (byte)RpcCalls.SetRole, RpcSendOption, clientId);
         writer.Write((ushort)role);
         writer.Write(true);
         AmongUsClient.Instance.FinishRpcImmediately(writer);

--- a/Modules/RPC.cs
+++ b/Modules/RPC.cs
@@ -1050,12 +1050,12 @@ internal class StartRpcPatch
 [HarmonyPatch(typeof(InnerNetClient), nameof(InnerNetClient.StartRpcImmediately))]
 public class StartRpcImmediatelyPatch
 {
-    public static void Postfix(InnerNetClient __instance, [HarmonyArgument(0)] uint targetNetId, [HarmonyArgument(1)] byte callId, [HarmonyArgument(2)] SendOption option, [HarmonyArgument(3)] int targetClientId, ref MessageWriter __result)
+    public static bool Prefix(InnerNetClient __instance, [HarmonyArgument(0)] uint targetNetId, [HarmonyArgument(1)] byte callId, [HarmonyArgument(2)] SendOption option, [HarmonyArgument(3)] int targetClientId, ref MessageWriter __result)
     {
-        if (callId < (byte)CustomRPC.VersionCheck || !AmongUsClient.Instance.AmHost || !GameStates.IsVanillaServer || option is SendOption.None)
+        if (callId < (byte)CustomRPC.VersionCheck || !AmongUsClient.Instance.AmHost || !GameStates.IsVanillaServer || GameStates.IsLocalGame || option is SendOption.None)
         {
             RPC.SendRpcLogger(targetNetId, callId, targetClientId);
-            return;
+            return true;
         }
 
         MessageWriter messageWriter = MessageWriter.Get(SendOption.None);
@@ -1074,9 +1074,8 @@ public class StartRpcImmediatelyPatch
         messageWriter.WritePacked(targetNetId);
         messageWriter.Write(callId);
 
-        __result.Recycle();
         __result = messageWriter;
         RPC.SendRpcLogger(targetNetId, callId, targetClientId);
-        return;
+        return false;
     }
 }

--- a/Modules/Utils.cs
+++ b/Modules/Utils.cs
@@ -40,10 +40,14 @@ public static class Utils
         if (!AmongUsClient.Instance.AmHost) return;
         foreach (var player in Main.AllPlayerControls.Where(x => x.GetClient() != null && !x.Data.Disconnected))
         {
-            var writer = AmongUsClient.Instance.StartRpcImmediately(player.NetId, (byte)RpcCalls.SendChat, SendOption.Reliable, player.OwnerId);
+            var writer = AmongUsClient.Instance.StartRpcImmediately(player.NetId, (byte)RpcCalls.SendChat, ExtendedPlayerControl.RpcSendOption, player.OwnerId);
             writer.Write(GetString("NotifyGameEnding"));
             AmongUsClient.Instance.FinishRpcImmediately(writer);
         }
+
+        var writer2 = AmongUsClient.Instance.StartRpcImmediately(PlayerControl.LocalPlayer.NetId, (byte)RpcCalls.SendChat, SendOption.Reliable, -1);
+        writer2.Write(GetString("NotifyGameEnding"));
+        AmongUsClient.Instance.FinishRpcImmediately(writer2);
     }
 
     public static ClientData GetClientById(int id)

--- a/Patches/ChatCommandPatch.cs
+++ b/Patches/ChatCommandPatch.cs
@@ -1032,26 +1032,26 @@ internal class ChatCommands
                     canceled = true;
                     Utils.SendMessage(GetString("Message.CanNotUseByHost"), PlayerControl.LocalPlayer.PlayerId);
                     break;
-
-                case "/xf":
-                case "/修复":
-                case "/修":
-                    canceled = true;
-                    if (GameStates.IsLobby)
-                    {
-                        Utils.SendMessage(GetString("Message.CanNotUseInLobby"), PlayerControl.LocalPlayer.PlayerId);
-                        break;
-                    }
-                    foreach (var pc in Main.AllPlayerControls)
-                    {
-                        if (!pc.IsAlive()) continue;
-                        pc.RpcSetNameEx(pc.GetRealName(isMeeting: true));
-                    }
-                    ChatUpdatePatch.DoBlockChat = false;
-                    //Utils.NotifyRoles(isForMeeting: GameStates.IsMeeting, NoCache: true);
-                    Utils.SendMessage(GetString("Message.TryFixName"), PlayerControl.LocalPlayer.PlayerId);
-                    break;
-
+                /*
+                                case "/xf":
+                                case "/修复":
+                                case "/修":
+                                    canceled = true;
+                                    if (GameStates.IsLobby)
+                                    {
+                                        Utils.SendMessage(GetString("Message.CanNotUseInLobby"), PlayerControl.LocalPlayer.PlayerId);
+                                        break;
+                                    }
+                                    foreach (var pc in Main.AllPlayerControls)
+                                    {
+                                        if (!pc.IsAlive()) continue;
+                                        pc.RpcSetNameEx(pc.GetRealName(isMeeting: true));
+                                    }
+                                    ChatUpdatePatch.DoBlockChat = false;
+                                    //Utils.NotifyRoles(isForMeeting: GameStates.IsMeeting, NoCache: true);
+                                    Utils.SendMessage(GetString("Message.TryFixName"), PlayerControl.LocalPlayer.PlayerId);
+                                    break;
+                */
                 case "/id":
                 case "/айди":
                 case "/编号":
@@ -3021,24 +3021,26 @@ internal class ChatCommands
                 }
                 break;
 
-            case "/xf":
-            case "/修复":
-            case "/修":
-                if (GameStates.IsLobby)
-                {
-                    Utils.SendMessage(GetString("Message.CanNotUseInLobby"), player.PlayerId);
-                    break;
-                }
-                foreach (var pc in Main.AllPlayerControls)
-                {
-                    if (!pc.IsAlive()) continue;
+            /*
+                        case "/xf":
+                        case "/修复":
+                        case "/修":
+                            if (GameStates.IsLobby)
+                            {
+                                Utils.SendMessage(GetString("Message.CanNotUseInLobby"), player.PlayerId);
+                                break;
+                            }
+                            foreach (var pc in Main.AllPlayerControls)
+                            {
+                                if (!pc.IsAlive()) continue;
 
-                    pc.RpcSetNamePrivate(pc.GetRealName(isMeeting: true), player, true);
-                }
-                ChatUpdatePatch.DoBlockChat = false;
-                //Utils.NotifyRoles(isForMeeting: GameStates.IsMeeting, NoCache: true);
-                Utils.SendMessage(GetString("Message.TryFixName"), player.PlayerId);
-                break;
+                                pc.RpcSetNamePrivate(pc.GetRealName(isMeeting: true), player, true);
+                            }
+                            ChatUpdatePatch.DoBlockChat = false;
+                            //Utils.NotifyRoles(isForMeeting: GameStates.IsMeeting, NoCache: true);
+                            Utils.SendMessage(GetString("Message.TryFixName"), player.PlayerId);
+                            break;
+            */
 
             case "/tpout":
             case "/传送出":

--- a/Patches/ChatCommandPatch.cs
+++ b/Patches/ChatCommandPatch.cs
@@ -1044,7 +1044,8 @@ internal class ChatCommands
                     }
                     foreach (var pc in Main.AllPlayerControls)
                     {
-                        if (!pc.IsAlive()) continue;
+                        if (pc.IsAlive()) continue;
+
                         pc.RpcSetNameEx(pc.GetRealName(isMeeting: true));
                     }
                     ChatUpdatePatch.DoBlockChat = false;
@@ -3031,9 +3032,9 @@ internal class ChatCommands
                 }
                 foreach (var pc in Main.AllPlayerControls)
                 {
-                    if (!pc.IsAlive()) continue;
+                    if (pc.IsAlive()) continue;
 
-                    pc.RpcSetNamePrivate(pc.GetRealName(isMeeting: true), player, true);
+                    pc.RpcSetNameEx(pc.GetRealName(isMeeting: true));
                 }
                 ChatUpdatePatch.DoBlockChat = false;
                 //Utils.NotifyRoles(isForMeeting: GameStates.IsMeeting, NoCache: true);

--- a/Patches/ChatCommandPatch.cs
+++ b/Patches/ChatCommandPatch.cs
@@ -1032,26 +1032,26 @@ internal class ChatCommands
                     canceled = true;
                     Utils.SendMessage(GetString("Message.CanNotUseByHost"), PlayerControl.LocalPlayer.PlayerId);
                     break;
-                /*
-                                case "/xf":
-                                case "/修复":
-                                case "/修":
-                                    canceled = true;
-                                    if (GameStates.IsLobby)
-                                    {
-                                        Utils.SendMessage(GetString("Message.CanNotUseInLobby"), PlayerControl.LocalPlayer.PlayerId);
-                                        break;
-                                    }
-                                    foreach (var pc in Main.AllPlayerControls)
-                                    {
-                                        if (!pc.IsAlive()) continue;
-                                        pc.RpcSetNameEx(pc.GetRealName(isMeeting: true));
-                                    }
-                                    ChatUpdatePatch.DoBlockChat = false;
-                                    //Utils.NotifyRoles(isForMeeting: GameStates.IsMeeting, NoCache: true);
-                                    Utils.SendMessage(GetString("Message.TryFixName"), PlayerControl.LocalPlayer.PlayerId);
-                                    break;
-                */
+
+                case "/xf":
+                case "/修复":
+                case "/修":
+                    canceled = true;
+                    if (GameStates.IsLobby)
+                    {
+                        Utils.SendMessage(GetString("Message.CanNotUseInLobby"), PlayerControl.LocalPlayer.PlayerId);
+                        break;
+                    }
+                    foreach (var pc in Main.AllPlayerControls)
+                    {
+                        if (pc.IsAlive()) continue;
+                        pc.SetName(pc.GetRealName(isMeeting: true));
+                    }
+                    ChatUpdatePatch.DoBlockChat = false;
+                    //Utils.NotifyRoles(isForMeeting: GameStates.IsMeeting, NoCache: true);
+                    Utils.SendMessage(GetString("Message.TryFixName"), PlayerControl.LocalPlayer.PlayerId);
+                    break;
+
                 case "/id":
                 case "/айди":
                 case "/编号":
@@ -3021,26 +3021,24 @@ internal class ChatCommands
                 }
                 break;
 
-            /*
-                        case "/xf":
-                        case "/修复":
-                        case "/修":
-                            if (GameStates.IsLobby)
-                            {
-                                Utils.SendMessage(GetString("Message.CanNotUseInLobby"), player.PlayerId);
-                                break;
-                            }
-                            foreach (var pc in Main.AllPlayerControls)
-                            {
-                                if (!pc.IsAlive()) continue;
+            case "/xf":
+            case "/修复":
+            case "/修":
+                if (GameStates.IsLobby)
+                {
+                    Utils.SendMessage(GetString("Message.CanNotUseInLobby"), player.PlayerId);
+                    break;
+                }
+                foreach (var pc in Main.AllPlayerControls)
+                {
+                    if (pc.IsAlive()) continue;
 
-                                pc.RpcSetNamePrivate(pc.GetRealName(isMeeting: true), player, true);
-                            }
-                            ChatUpdatePatch.DoBlockChat = false;
-                            //Utils.NotifyRoles(isForMeeting: GameStates.IsMeeting, NoCache: true);
-                            Utils.SendMessage(GetString("Message.TryFixName"), player.PlayerId);
-                            break;
-            */
+                    pc.RpcSetNamePrivate(pc.GetRealName(isMeeting: true), player, true);
+                }
+                ChatUpdatePatch.DoBlockChat = false;
+                //Utils.NotifyRoles(isForMeeting: GameStates.IsMeeting, NoCache: true);
+                Utils.SendMessage(GetString("Message.TryFixName"), player.PlayerId);
+                break;
 
             case "/tpout":
             case "/传送出":

--- a/Patches/ChatCommandPatch.cs
+++ b/Patches/ChatCommandPatch.cs
@@ -1044,8 +1044,7 @@ internal class ChatCommands
                     }
                     foreach (var pc in Main.AllPlayerControls)
                     {
-                        if (pc.IsAlive()) continue;
-
+                        if (!pc.IsAlive()) continue;
                         pc.RpcSetNameEx(pc.GetRealName(isMeeting: true));
                     }
                     ChatUpdatePatch.DoBlockChat = false;
@@ -3032,9 +3031,9 @@ internal class ChatCommands
                 }
                 foreach (var pc in Main.AllPlayerControls)
                 {
-                    if (pc.IsAlive()) continue;
+                    if (!pc.IsAlive()) continue;
 
-                    pc.RpcSetNameEx(pc.GetRealName(isMeeting: true));
+                    pc.RpcSetNamePrivate(pc.GetRealName(isMeeting: true), player, true);
                 }
                 ChatUpdatePatch.DoBlockChat = false;
                 //Utils.NotifyRoles(isForMeeting: GameStates.IsMeeting, NoCache: true);

--- a/Patches/PlayerControlPatch.cs
+++ b/Patches/PlayerControlPatch.cs
@@ -1071,8 +1071,7 @@ class FixedUpdateInNormalGamePatch
 {
     private static readonly StringBuilder Mark = new(20);
     private static readonly StringBuilder Suffix = new(120);
-    public static readonly Dictionary<byte, int> BufferTime = [];
-    public static readonly Dictionary<byte, int> TeleportBuffer = [];
+    private static readonly Dictionary<byte, int> BufferTime = [];
     private static int LevelKickBufferTime = 20;
 
     public static async void Postfix(PlayerControl __instance)
@@ -1142,11 +1141,6 @@ class FixedUpdateInNormalGamePatch
         }
 
         BufferTime[player.PlayerId] = timerLowLoad;
-
-        if (__instance.AmOwner && timerLowLoad == 30)
-        {
-            TeleportBuffer.Clear();
-        }
 
         if (!lowLoad)
         {

--- a/Patches/PlayerControlPatch.cs
+++ b/Patches/PlayerControlPatch.cs
@@ -1071,7 +1071,8 @@ class FixedUpdateInNormalGamePatch
 {
     private static readonly StringBuilder Mark = new(20);
     private static readonly StringBuilder Suffix = new(120);
-    private static readonly Dictionary<byte, int> BufferTime = [];
+    public static readonly Dictionary<byte, int> BufferTime = [];
+    public static readonly Dictionary<byte, int> TeleportBuffer = [];
     private static int LevelKickBufferTime = 20;
 
     public static async void Postfix(PlayerControl __instance)
@@ -1141,6 +1142,11 @@ class FixedUpdateInNormalGamePatch
         }
 
         BufferTime[player.PlayerId] = timerLowLoad;
+
+        if (__instance.AmOwner && timerLowLoad == 30)
+        {
+            TeleportBuffer.Clear();
+        }
 
         if (!lowLoad)
         {

--- a/Patches/PlayerJoinAndLeftPatch.cs
+++ b/Patches/PlayerJoinAndLeftPatch.cs
@@ -29,7 +29,7 @@ class OnGameJoinedPatch
             Main.VersionCheat.Value = false;
 
         ChatUpdatePatch.DoBlockChat = false;
-        Main.CurrentServerIsVanilla = GameStates.IsVanillaServer;
+        Main.CurrentServerIsVanilla = GameStates.IsVanillaServer && !GameStates.IsLocalGame;
         GameStates.InGame = false;
         ErrorText.Instance.Clear();
         EAC.Init();

--- a/Patches/TaskAssignPatch.cs
+++ b/Patches/TaskAssignPatch.cs
@@ -321,7 +321,7 @@ class RpcSetTasksPatch
             __instance.SetTasks((Il2CppStructArray<byte>)TasksList.ToArray());
         }
 
-        MessageWriter messageWriter = AmongUsClient.Instance.StartRpc(__instance.NetId, 29, SendOption.Reliable);
+        MessageWriter messageWriter = AmongUsClient.Instance.StartRpc(__instance.NetId, (byte)RpcCalls.SetTasks, SendOption.Reliable);
         messageWriter.WriteBytesAndSize((Il2CppStructArray<byte>)TasksList.ToArray());
         messageWriter.EndMessage();
         return false;

--- a/Patches/onGameStartedPatch.cs
+++ b/Patches/onGameStartedPatch.cs
@@ -75,7 +75,7 @@ internal class ChangeRoleSettings
             Main.DeadPassedMeetingPlayers.Clear();
             Main.OvverideOutfit.Clear();
             Main.GameIsLoaded = false;
-            Main.CurrentServerIsVanilla = GameStates.IsVanillaServer;
+            Main.CurrentServerIsVanilla = GameStates.IsVanillaServer && !GameStates.IsLocalGame;
 
             Main.LastNotifyNames.Clear();
 

--- a/Patches/onGameStartedPatch.cs
+++ b/Patches/onGameStartedPatch.cs
@@ -395,26 +395,10 @@ internal class StartGameHostPatch
             // Assign roles and create role map for normal roles
             RpcSetRoleReplacer.AssignNormalRoles();
             RpcSetRoleReplacer.SendRpcForNormal();
-        }
-        catch (Exception ex)
-        {
-            CriticalErrorManager.SetCreiticalError("Select Role Prefix - Building Role Sender", true, ex.ToString());
-            Utils.ThrowException(ex);
-            yield break;
-        }
 
-        if (!Main.CurrentServerIsVanilla)
-        {
-            // Send all Rpc for modded region
+            // Send all Rpc
             RpcSetRoleReplacer.Release();
-        }
-        else
-        {
-            yield return RpcSetRoleReplacer.ReleaseVanilla();
-        }
 
-        try
-        {
             foreach (var pc in PlayerControl.AllPlayerControls.GetFastEnumerator())
             {
                 if (Main.PlayerStates[pc.PlayerId].MainRole != CustomRoles.NotAssigned) continue;
@@ -527,7 +511,7 @@ internal class StartGameHostPatch
         }
         catch (Exception ex)
         {
-            CriticalErrorManager.SetCreiticalError("Select Role Prefix - Building Role classes", true, ex.ToString());
+            CriticalErrorManager.SetCreiticalError("Select Role Prefix", true, ex.ToString());
             Utils.ThrowException(ex);
             yield break;
         }
@@ -830,17 +814,6 @@ public static class RpcSetRoleReplacer
         BlockSetRole = false;
         Senders.Do(kvp => kvp.Value.SendMessage());
     }
-
-    public static System.Collections.IEnumerator ReleaseVanilla()
-    {
-        BlockSetRole = false;
-        foreach (var kvp in Senders)
-        {
-            kvp.Value.SendMessage();
-            yield return new WaitForSeconds(0.3f);
-        }
-    }
-
     public static void EndReplace()
     {
         Senders = null;

--- a/Patches/onGameStartedPatch.cs
+++ b/Patches/onGameStartedPatch.cs
@@ -395,10 +395,26 @@ internal class StartGameHostPatch
             // Assign roles and create role map for normal roles
             RpcSetRoleReplacer.AssignNormalRoles();
             RpcSetRoleReplacer.SendRpcForNormal();
+        }
+        catch (Exception ex)
+        {
+            CriticalErrorManager.SetCreiticalError("Select Role Prefix - Building Role Sender", true, ex.ToString());
+            Utils.ThrowException(ex);
+            yield break;
+        }
 
-            // Send all Rpc
+        if (!Main.CurrentServerIsVanilla)
+        {
+            // Send all Rpc for modded region
             RpcSetRoleReplacer.Release();
+        }
+        else
+        {
+            yield return RpcSetRoleReplacer.ReleaseVanilla();
+        }
 
+        try
+        {
             foreach (var pc in PlayerControl.AllPlayerControls.GetFastEnumerator())
             {
                 if (Main.PlayerStates[pc.PlayerId].MainRole != CustomRoles.NotAssigned) continue;
@@ -511,7 +527,7 @@ internal class StartGameHostPatch
         }
         catch (Exception ex)
         {
-            CriticalErrorManager.SetCreiticalError("Select Role Prefix", true, ex.ToString());
+            CriticalErrorManager.SetCreiticalError("Select Role Prefix - Building Role classes", true, ex.ToString());
             Utils.ThrowException(ex);
             yield break;
         }
@@ -814,6 +830,17 @@ public static class RpcSetRoleReplacer
         BlockSetRole = false;
         Senders.Do(kvp => kvp.Value.SendMessage());
     }
+
+    public static System.Collections.IEnumerator ReleaseVanilla()
+    {
+        BlockSetRole = false;
+        foreach (var kvp in Senders)
+        {
+            kvp.Value.SendMessage();
+            yield return new WaitForSeconds(0.3f);
+        }
+    }
+
     public static void EndReplace()
     {
         Senders = null;

--- a/Roles/Impostor/Penguin.cs
+++ b/Roles/Impostor/Penguin.cs
@@ -246,6 +246,8 @@ internal class Penguin : RoleBase
             // SnapToRPC does not work for players on top of the ladder, and only the host behaves differently, so teleporting is not done uniformly.
             else if (!AbductVictim.MyPhysics.Animations.IsPlayingAnyLadderAnimation())
             {
+                if (Main.CurrentServerIsVanilla && timerLowLoad % 3 != 0) return;
+
                 var position = penguin.transform.position;
                 if (!penguin.IsHost())
                 {

--- a/Roles/Impostor/Penguin.cs
+++ b/Roles/Impostor/Penguin.cs
@@ -246,8 +246,6 @@ internal class Penguin : RoleBase
             // SnapToRPC does not work for players on top of the ladder, and only the host behaves differently, so teleporting is not done uniformly.
             else if (!AbductVictim.MyPhysics.Animations.IsPlayingAnyLadderAnimation())
             {
-                if (Main.CurrentServerIsVanilla && timerLowLoad % 3 != 0) return;
-
                 var position = penguin.transform.position;
                 if (!penguin.IsHost())
                 {


### PR DESCRIPTION
1. Cook a buffer like fixed update buffer for Rpc teleport
This makes sure that only 5 snapto is sent with reliable per second for a single player, while the other is sent with none
2. Send RoleSenders with a 0.3f delay per player on officials.
We need to keep set role in reliable. I guess this still cause kicks
3. Force send all Custom Rpcs with None by patching StartRpcImmediately
4. /xf set name locally for host. Use rpc set name private for clients.
5. rpc set name private now send with none on officials