### PR TITLE
Update RoleAssign.cs

### DIFF
--- a/Roles/Core/AssignManager/RoleAssign.cs
+++ b/Roles/Core/AssignManager/RoleAssign.cs
@@ -50,6 +50,7 @@ public class RoleAssign
 
     public static void StartSelect()
     {
+        IRandom.SetInstance(new MersenneTwister());
         switch (Options.CurrentGameMode)
         {
             case CustomGameMode.FFA:


### PR DESCRIPTION
Vanilla Among Us is random. With ToH-E the player roles have a pattern when multiple games are played without breaking the lobby or changing any players. This might be exasperated by having 7 players, but I haven't tested enough to confirm. 'MersenneTwister.cs' seems to seed players by date/time but I think that only happens at creation of the lobby, based on my testing. I wanted to try to reseed them between games. This change builds and in my testing fixed the randomization. I am not a coder, I won't be offended if this isn't used but *please* fix the randomization between games within the same lobby. Thanks. :)

If you don't believe that it's not random within the same lobby, I can share my test results or you can test yourself. I used 7 players, 2 imposters, 1 neutral role, and 1 crewmate special role over 30 games. I did it with vanilla Among Us (random) and ToH-Enhanced (not random), about 30 games each. I think this issue also exists in ToH (not Enhanced).