### PR TITLE
Various Necromancer Fixes

### DIFF
--- a/Modules/ExtendedPlayerControl.cs
+++ b/Modules/ExtendedPlayerControl.cs
@@ -1358,8 +1358,8 @@ static class ExtendedPlayerControl
         else if (Ritualist.EnchantedKnowsCoven.GetBool() && seer.Is(CustomRoles.Enchanted) && target.Is(Custom_Team.Coven)) return true;
         else if (target.Is(CustomRoles.Enchanted) && seer.Is(Custom_Team.Coven)) return true;
         else if (target.Is(Custom_Team.Coven) && seer.Is(Custom_Team.Coven)) return true;
-        else if (target.GetRoleClass().KnowRoleTarget(seer, target) && !Main.PlayerStates[seer.PlayerId].IsNecromancer && !Main.PlayerStates[target.PlayerId].IsNecromancer) return true;
-        else if (seer.GetRoleClass().KnowRoleTarget(seer, target) && !Main.PlayerStates[seer.PlayerId].IsNecromancer && !Main.PlayerStates[target.PlayerId].IsNecromancer) return true;
+        else if (target.GetRoleClass().KnowRoleTarget(seer, target)) return true;
+        else if (seer.GetRoleClass().KnowRoleTarget(seer, target)) return true;
         else if (Solsticer.OtherKnowSolsticer(target)) return true;
         else if (Overseer.IsRevealedPlayer(seer, target) /*&& !target.Is(CustomRoles.Trickster)*/) return true;
         //↑↑I disabled the part that checks target is not trickster because I found it causing modded Overseers unable to see random role texts in meetings

--- a/Modules/ExtendedPlayerControl.cs
+++ b/Modules/ExtendedPlayerControl.cs
@@ -1354,6 +1354,7 @@ static class ExtendedPlayerControl
         else if (Madmate.MadmateKnowWhosImp.GetBool() && seer.Is(CustomRoles.Madmate) && target.Is(Custom_Team.Impostor) && !Main.PlayerStates[seer.PlayerId].IsNecromancer && !Main.PlayerStates[target.PlayerId].IsNecromancer) return true;
         else if (Madmate.ImpKnowWhosMadmate.GetBool() && target.Is(CustomRoles.Madmate) && seer.Is(Custom_Team.Impostor) && !Main.PlayerStates[seer.PlayerId].IsNecromancer && !Main.PlayerStates[target.PlayerId].IsNecromancer) return true;
         else if (seer.Is(Custom_Team.Impostor) && target.GetCustomRole().IsGhostRole() && target.GetCustomRole().IsImpostor() && !Main.PlayerStates[seer.PlayerId].IsNecromancer && !Main.PlayerStates[target.PlayerId].IsNecromancer) return true;
+        else if (seer.IsNeutralApocalypse() && target.IsNeutralApocalypse() && !Main.PlayerStates[seer.PlayerId].IsNecromancer && !Main.PlayerStates[target.PlayerId].IsNecromancer) return true;
         else if (Ritualist.EnchantedKnowsCoven.GetBool() && seer.Is(CustomRoles.Enchanted) && target.Is(Custom_Team.Coven)) return true;
         else if (target.Is(CustomRoles.Enchanted) && seer.Is(Custom_Team.Coven)) return true;
         else if (target.Is(Custom_Team.Coven) && seer.Is(Custom_Team.Coven)) return true;

--- a/Modules/NameColorManager.cs
+++ b/Modules/NameColorManager.cs
@@ -107,6 +107,7 @@ public static class NameColorManager
             || seer.Is(CustomRoles.GM) || target.Is(CustomRoles.GM)
             || target.GetRoleClass().OthersKnowTargetRoleColor(seer, target)
             || Mimic.CanSeeDeadRoles(seer, target)
+            || (seer.IsNeutralApocalypse() && target.IsNeutralApocalypse() && !Main.PlayerStates[seer.PlayerId].IsNecromancer && !Main.PlayerStates[target.PlayerId].IsNecromancer)
             || (seer.Is(Custom_Team.Impostor) && target.Is(Custom_Team.Impostor) && !Main.PlayerStates[seer.PlayerId].IsNecromancer && !Main.PlayerStates[target.PlayerId].IsNecromancer)
             || (seer.Is(CustomRoles.Madmate) && target.Is(Custom_Team.Impostor) && Madmate.MadmateKnowWhosImp.GetBool() && !Main.PlayerStates[seer.PlayerId].IsNecromancer && !Main.PlayerStates[target.PlayerId].IsNecromancer)
             || (seer.Is(Custom_Team.Impostor) && target.Is(CustomRoles.Madmate) && Madmate.ImpKnowWhosMadmate.GetBool() && !Main.PlayerStates[seer.PlayerId].IsNecromancer && !Main.PlayerStates[target.PlayerId].IsNecromancer)

--- a/Roles/Coven/Necromancer.cs
+++ b/Roles/Coven/Necromancer.cs
@@ -228,7 +228,8 @@ internal class Necromancer : CovenManager
             CustomRoles.Sunnyboy ||
             (role == CustomRoles.Workaholic && Workaholic.WorkaholicVisibleToEveryone.GetBool()) ||
             (role == CustomRoles.Mayor && Mayor.MayorRevealWhenDoneTasks.GetBool()) ||
-            (role == CustomRoles.Executioner && Executioner.KnowTargetRole.GetBool());
+            (role == CustomRoles.Executioner && Executioner.KnowTargetRole.GetBool()) ||
+            (role == CustomRoles.Doctor && Doctor.VisibleToEveryoneOpt.GetBool());
     }
     public override void OnFixedUpdate(PlayerControl player, bool lowLoad, long nowTime, int timerLowLoad)
     {

--- a/Roles/Crewmate/Admirer.cs
+++ b/Roles/Crewmate/Admirer.cs
@@ -187,7 +187,7 @@ internal class Admirer : RoleBase
         return false;
     }
 
-    public override bool KnowRoleTarget(PlayerControl seer, PlayerControl target) => CheckKnowRoleTarget(seer, target);
+    public override bool KnowRoleTarget(PlayerControl seer, PlayerControl target) => CheckKnowRoleTarget(seer, target) && !Main.PlayerStates[seer.PlayerId].IsNecromancer;
 
     public static bool CheckKnowRoleTarget(PlayerControl seer, PlayerControl target)
     {

--- a/Roles/Crewmate/ChiefOfPolice.cs
+++ b/Roles/Crewmate/ChiefOfPolice.cs
@@ -1,7 +1,9 @@
+using TOHE.Roles.AddOns.Common;
 using TOHE.Roles.Core;
 using UnityEngine;
 using static TOHE.Options;
 using static TOHE.Translator;
+using static UnityEngine.ParticleSystem.PlaybackState;
 
 namespace TOHE.Roles.Crewmate;
 
@@ -121,6 +123,7 @@ internal class ChiefOfPolice : RoleBase
                     target.RpcChangeRoleBasis(CustomRoles.Sheriff);
                     target.RpcSetCustomRole(CustomRoles.Sheriff);
                     target.GetRoleClass()?.OnAdd(target.PlayerId);
+                    if (Main.PlayerStates[target.PlayerId].IsNecromancer) Main.PlayerStates[target.PlayerId].IsNecromancer = false;
 
                     target.ResetKillCooldown();
                     target.SetKillCooldown(forceAnime: true);

--- a/Roles/Crewmate/Doctor.cs
+++ b/Roles/Crewmate/Doctor.cs
@@ -14,7 +14,7 @@ internal class Doctor : RoleBase
     //==================================================================\\
 
     private static OptionItem TaskCompletedBatteryChargeOpt;
-    private static OptionItem VisibleToEveryoneOpt;
+    public static OptionItem VisibleToEveryoneOpt;
 
     public override void SetupCustomOption()
     {

--- a/Roles/Neutral/Baker.cs
+++ b/Roles/Neutral/Baker.cs
@@ -6,6 +6,7 @@ using TOHE.Roles.Core;
 using static TOHE.Options;
 using static TOHE.Translator;
 using static TOHE.Utils;
+using static UnityEngine.GraphicsBuffer;
 
 namespace TOHE.Roles.Neutral;
 
@@ -231,7 +232,7 @@ internal class Baker : RoleBase
         if (!CanUseAbility)
             killer.Notify(GetString("BakerBreadUsedAlready"));
 
-        else if (target.IsNeutralApocalypse())
+        else if (target.IsNeutralApocalypse() && !Main.PlayerStates[target.PlayerId].IsNecromancer)
             killer.Notify(GetString("BakerCantBreadApoc"));
 
         else if (HasBread(killer.PlayerId, target.PlayerId))
@@ -312,7 +313,7 @@ internal class Baker : RoleBase
     {
         if (lowLoad || player.Is(CustomRoles.Famine)) return;
 
-        if (AllHasBread(player) || (TransformNoMoreBread.GetBool() && BreadedPlayerCount(player.PlayerId).Item1 >= Main.AllAlivePlayerControls.Where(x => !x.IsNeutralApocalypse()).Count()))
+        if (AllHasBread(player) || (TransformNoMoreBread.GetBool() && BreadedPlayerCount(player.PlayerId).Item1 >= Main.AllAlivePlayerControls.Where(x => !x.IsNeutralApocalypse() && !Main.PlayerStates[x.PlayerId].IsNecromancer).Count()))
         {
             player.RpcChangeRoleBasis(CustomRoles.Famine);
             player.RpcSetCustomRole(CustomRoles.Famine);
@@ -369,7 +370,7 @@ internal class Famine : RoleBase
 
     public override bool ForcedCheckMurderAsKiller(PlayerControl killer, PlayerControl target)
     {
-        if (target.IsNeutralApocalypse())
+        if (target.IsNeutralApocalypse() && !Main.PlayerStates[target.PlayerId].IsNecromancer)
             killer.Notify(GetString("FamineCantStarveApoc"));
 
         else if (FamineList[killer.PlayerId].Contains(target.PlayerId))
@@ -422,7 +423,7 @@ internal class Famine : RoleBase
         var baker = _Player;
         foreach (var pc in Main.AllAlivePlayerControls)
         {
-            if (pc.IsNeutralApocalypse() || Baker.HasBread(baker.PlayerId, pc.PlayerId)) continue;
+            if ((pc.IsNeutralApocalypse() && !Main.PlayerStates[pc.PlayerId].IsNecromancer) || Baker.HasBread(baker.PlayerId, pc.PlayerId)) continue;
             if (baker.IsAlive())
             {
                 if (!Main.AfterMeetingDeathPlayers.ContainsKey(pc.PlayerId))

--- a/Roles/Neutral/Baker.cs
+++ b/Roles/Neutral/Baker.cs
@@ -340,7 +340,6 @@ internal class Famine : RoleBase
     {
         CustomRoleManager.CheckDeadBodyOthers.Add(OnPlayerDead);
     }
-    public override bool OthersKnowTargetRoleColor(PlayerControl seer, PlayerControl target) => KnowRoleTarget(seer, target);
     public override bool KnowRoleTarget(PlayerControl seer, PlayerControl target) => CustomRoles.Baker.GetStaticRoleClass().KnowRoleTarget(seer, target);
     public override void SetKillCooldown(byte id) => Main.AllPlayerKillCooldown[id] = Baker.FamineStarveCooldown.GetFloat();
     public override void ApplyGameOptions(IGameOptions opt, byte playerId) => opt.SetVision(true);

--- a/Roles/Neutral/Baker.cs
+++ b/Roles/Neutral/Baker.cs
@@ -116,10 +116,9 @@ internal class Baker : RoleBase
         }
     }
     public override string GetProgressText(byte playerId, bool comms) => ColorString(GetRoleColor(CustomRoles.Baker).ShadeColor(0.25f), $"({BreadedPlayerCount(playerId).Item1}/{BreadedPlayerCount(playerId).Item2})");
-    public override bool OthersKnowTargetRoleColor(PlayerControl seer, PlayerControl target) => KnowRoleTarget(seer, target);
     public override bool KnowRoleTarget(PlayerControl seer, PlayerControl target)
     {
-        if (target.IsNeutralApocalypse() && seer.IsNeutralApocalypse()) return true;
+        // if (target.IsNeutralApocalypse() && seer.IsNeutralApocalypse()) return true;
         // i swear this isn't consigliere's code i swear
         if (seer.IsAlive() && RevealList.TryGetValue(seer.PlayerId, out var targets))
         {
@@ -145,7 +144,7 @@ internal class Baker : RoleBase
     public override string GetMarkOthers(PlayerControl seer, PlayerControl target, bool isForMeeting = false)
     {
         if (!_Player) return string.Empty;
-        if (HasBread(_Player.PlayerId, target.PlayerId) && seer.IsNeutralApocalypse() && seer.PlayerId != _Player.PlayerId)
+        if (HasBread(_Player.PlayerId, target.PlayerId) && seer.IsNeutralApocalypse() && seer.PlayerId != _Player.PlayerId && !Main.PlayerStates[seer.PlayerId].IsNecromancer)
         {
             return ColorString(GetRoleColor(CustomRoles.Baker), "●");
         }

--- a/Roles/Neutral/Berserker.cs
+++ b/Roles/Neutral/Berserker.cs
@@ -195,8 +195,6 @@ internal class War : RoleBase
     public override Custom_RoleType ThisRoleType => Custom_RoleType.NeutralApocalypse;
     //==================================================================\\
 
-    public override bool OthersKnowTargetRoleColor(PlayerControl seer, PlayerControl target)
-        => KnowRoleTarget(seer, target);
     public override void SetKillCooldown(byte id) => Main.AllPlayerKillCooldown[id] = Berserker.WarKillCooldown.GetFloat();
     public override void ApplyGameOptions(IGameOptions opt, byte playerId) => opt.SetVision(Berserker.WarHasImpostorVision.GetBool());
     public override bool CanUseKillButton(PlayerControl pc) => true;

--- a/Roles/Neutral/Berserker.cs
+++ b/Roles/Neutral/Berserker.cs
@@ -106,7 +106,7 @@ internal class Berserker : RoleBase
     public override bool CanUseKillButton(PlayerControl pc) => pc.IsAlive();
     public override bool OnCheckMurderAsKiller(PlayerControl killer, PlayerControl target)
     {
-        if (target.IsNeutralApocalypse() && !BerserkerCanKillTeamate.GetBool()) return false;
+        if (target.IsNeutralApocalypse() && !BerserkerCanKillTeamate.GetBool() && !Main.PlayerStates[target.PlayerId].IsNecromancer) return false;
 
         bool noScav = true;
         if (BerserkerKillMax[killer.PlayerId] < BerserkerMax.GetInt())
@@ -157,13 +157,13 @@ internal class Berserker : RoleBase
 
                 if (Utils.GetDistance(killer.transform.position, player.transform.position) <= Bomber.BomberRadius.GetFloat())
                 {
-                    if (!target.IsNeutralApocalypse())
+                    if (!target.IsNeutralApocalypse() || Main.PlayerStates[target.PlayerId].IsNecromancer)
                     {
                         Main.PlayerStates[player.PlayerId].deathReason = PlayerState.DeathReason.Bombed;
                         player.RpcMurderPlayer(player);
                         player.SetRealKiller(killer);
                     }
-                    if (target.IsNeutralApocalypse() && BerserkerCanKillTeamate.GetBool())
+                    if (target.IsNeutralApocalypse() && BerserkerCanKillTeamate.GetBool() && !Main.PlayerStates[target.PlayerId].IsNecromancer)
                     {
                         Main.PlayerStates[player.PlayerId].deathReason = PlayerState.DeathReason.Bombed;
                         player.RpcMurderPlayer(player);

--- a/Roles/Neutral/Berserker.cs
+++ b/Roles/Neutral/Berserker.cs
@@ -99,10 +99,6 @@ internal class Berserker : RoleBase
 
         BerserkerKillMax[_Player.PlayerId] = killCount;
     }
-    public override bool OthersKnowTargetRoleColor(PlayerControl seer, PlayerControl target)
-        => KnowRoleTarget(seer, target);
-    public override bool KnowRoleTarget(PlayerControl seer, PlayerControl target)
-        => target.IsNeutralApocalypse() && seer.IsNeutralApocalypse();
     public override string GetProgressText(byte playerId, bool cvooms) => Utils.ColorString(Utils.GetRoleColor(CustomRoles.Berserker).ShadeColor(0.25f), BerserkerKillMax.TryGetValue(playerId, out var x) ? $"({x}/{BerserkerMax.GetInt()})" : "Invalid");
     public override bool CanUseImpostorVentButton(PlayerControl pc) => BerserkerCanVent.GetBool();
     public override void ApplyGameOptions(IGameOptions opt, byte playerId)
@@ -201,8 +197,6 @@ internal class War : RoleBase
 
     public override bool OthersKnowTargetRoleColor(PlayerControl seer, PlayerControl target)
         => KnowRoleTarget(seer, target);
-    public override bool KnowRoleTarget(PlayerControl seer, PlayerControl target)
-        => target.IsNeutralApocalypse() && seer.IsNeutralApocalypse();
     public override void SetKillCooldown(byte id) => Main.AllPlayerKillCooldown[id] = Berserker.WarKillCooldown.GetFloat();
     public override void ApplyGameOptions(IGameOptions opt, byte playerId) => opt.SetVision(Berserker.WarHasImpostorVision.GetBool());
     public override bool CanUseKillButton(PlayerControl pc) => true;

--- a/Roles/Neutral/PlagueBearer.cs
+++ b/Roles/Neutral/PlagueBearer.cs
@@ -75,10 +75,6 @@ internal class PlagueBearer : RoleBase
     public override bool CanUseImpostorVentButton(PlayerControl pc) => PlagueBearerCanVent.GetBool();
     public override void ApplyGameOptions(IGameOptions opt, byte playerId)
         => opt.SetVision(PlagueBearerHasImpostorVision.GetBool());
-    public override bool OthersKnowTargetRoleColor(PlayerControl seer, PlayerControl target) => KnowRoleTarget(seer, target);
-    public override bool KnowRoleTarget(PlayerControl seer, PlayerControl target)
-        => (target.IsNeutralApocalypse() && seer.IsNeutralApocalypse());
-
     public override void SetKillCooldown(byte id) => Main.AllPlayerKillCooldown[id] = PlagueBearerCooldownOpt.GetFloat();
     public override bool CanUseKillButton(PlayerControl pc) => true;
     private static bool IsPlagued(byte pc, byte target) => PlaguedList.TryGetValue(pc, out var Targets) && Targets.Contains(target);
@@ -218,7 +214,7 @@ internal class PlagueBearer : RoleBase
         => IsPlagued(seer.PlayerId, seen.PlayerId) ? ColorString(GetRoleColor(CustomRoles.PlagueBearer), "⦿") : string.Empty;
     public override string GetMarkOthers(PlayerControl seer, PlayerControl target, bool isForMeeting = false)
     {
-        if (playerIdList.Any() && IsPlagued(playerIdList.First(), target.PlayerId) && seer.IsNeutralApocalypse() && seer.PlayerId != playerIdList.First())
+        if (playerIdList.Any() && IsPlagued(playerIdList.First(), target.PlayerId) && seer.IsNeutralApocalypse() && seer.PlayerId != playerIdList.First() && !Main.PlayerStates[seer.PlayerId].IsNecromancer)
         {
             return ColorString(GetRoleColor(CustomRoles.PlagueBearer), "⦿");
         }
@@ -246,9 +242,6 @@ internal class Pestilence : RoleBase
     public override Custom_RoleType ThisRoleType => Custom_RoleType.NeutralApocalypse;
     //==================================================================\\
 
-    public override bool OthersKnowTargetRoleColor(PlayerControl seer, PlayerControl target) => KnowRoleTarget(seer, target);
-    public override bool KnowRoleTarget(PlayerControl seer, PlayerControl target)
-        => (target.IsNeutralApocalypse() && seer.IsNeutralApocalypse());
     public override void SetKillCooldown(byte id) => Main.AllPlayerKillCooldown[id] = PlagueBearer.PestilenceCooldownOpt.GetFloat();
     public override void ApplyGameOptions(IGameOptions opt, byte playerId) => opt.SetVision(PlagueBearer.PestilenceHasImpostorVision.GetBool());
     public override bool CanUseKillButton(PlayerControl pc) => true;

--- a/Roles/Neutral/PlagueBearer.cs
+++ b/Roles/Neutral/PlagueBearer.cs
@@ -249,14 +249,14 @@ internal class Pestilence : RoleBase
 
     public override bool OnCheckMurderAsTarget(PlayerControl killer, PlayerControl target)
     {
-        if (killer.IsNeutralApocalypse()) return false;
+        if (killer.IsNeutralApocalypse() && !Main.PlayerStates[killer.PlayerId].IsNecromancer) return false;
         target.RpcMurderPlayer(killer);
         killer.SetRealKiller(target);
         return false;
     }
     public override bool OnCheckMurderAsKiller(PlayerControl killer, PlayerControl target)
     {
-        if (target.IsNeutralApocalypse()) return false;
+        if (target.IsNeutralApocalypse() && !Main.PlayerStates[target.PlayerId].IsNecromancer) return false;
         return true;
     }
 

--- a/Roles/Neutral/SoulCollector.cs
+++ b/Roles/Neutral/SoulCollector.cs
@@ -170,7 +170,6 @@ internal class Death : RoleBase
     public override Custom_RoleType ThisRoleType => Custom_RoleType.NeutralApocalypse;
     //==================================================================\\
 
-    public override bool OthersKnowTargetRoleColor(PlayerControl seer, PlayerControl target) => KnowRoleTarget(seer, target);
     public override bool CanUseImpostorVentButton(PlayerControl pc) => SoulCollector.SoulCollectorCanVent.GetBool();
     public override bool OnCheckMurderAsTarget(PlayerControl killer, PlayerControl target) => false;
 

--- a/Roles/Neutral/SoulCollector.cs
+++ b/Roles/Neutral/SoulCollector.cs
@@ -68,9 +68,6 @@ internal class SoulCollector : RoleBase
         AbilityLimit = limit;
         TargetId = target;
     }
-    public override bool OthersKnowTargetRoleColor(PlayerControl seer, PlayerControl target) => KnowRoleTarget(seer, target);
-    public override bool KnowRoleTarget(PlayerControl seer, PlayerControl target)
-        => (target.IsNeutralApocalypse() && seer.IsNeutralApocalypse());
 
     public override string GetMark(PlayerControl seer, PlayerControl seen = null, bool isForMeeting = false)
         => TargetId == seen.PlayerId ? Utils.ColorString(Utils.GetRoleColor(CustomRoles.SoulCollector), "♠") : string.Empty;
@@ -78,7 +75,7 @@ internal class SoulCollector : RoleBase
     public override string GetMarkOthers(PlayerControl seer, PlayerControl target, bool isForMeeting = false)
     {
         if (_Player == null) return string.Empty;
-        if (TargetId == target.PlayerId && seer.IsNeutralApocalypse() && seer.PlayerId != _Player.PlayerId)
+        if (TargetId == target.PlayerId && seer.IsNeutralApocalypse() && seer.PlayerId != _Player.PlayerId && !Main.PlayerStates[seer.PlayerId].IsNecromancer)
         {
             return Utils.ColorString(Utils.GetRoleColor(CustomRoles.SoulCollector), "♠");
         }
@@ -174,8 +171,6 @@ internal class Death : RoleBase
     //==================================================================\\
 
     public override bool OthersKnowTargetRoleColor(PlayerControl seer, PlayerControl target) => KnowRoleTarget(seer, target);
-    public override bool KnowRoleTarget(PlayerControl seer, PlayerControl target)
-        => target.IsNeutralApocalypse() && seer.IsNeutralApocalypse();
     public override bool CanUseImpostorVentButton(PlayerControl pc) => SoulCollector.SoulCollectorCanVent.GetBool();
     public override bool OnCheckMurderAsTarget(PlayerControl killer, PlayerControl target) => false;
 

--- a/Roles/Neutral/SoulCollector.cs
+++ b/Roles/Neutral/SoulCollector.cs
@@ -4,6 +4,7 @@ using InnerNet;
 using TOHE.Roles.Core;
 using static TOHE.Options;
 using static TOHE.Translator;
+using static UnityEngine.GraphicsBuffer;
 
 namespace TOHE.Roles.Neutral;
 
@@ -181,7 +182,7 @@ internal class Death : RoleBase
         var death = _Player;
         foreach (var pc in Main.AllAlivePlayerControls)
         {
-            if (pc.IsNeutralApocalypse()) continue;
+            if (pc.IsNeutralApocalypse() && !Main.PlayerStates[pc.PlayerId].IsNecromancer) continue;
             if (death.IsAlive())
             {
                 if (!Main.AfterMeetingDeathPlayers.ContainsKey(pc.PlayerId))


### PR DESCRIPTION
Fix Necromancer and Apocalypse being able to see each other when Necromancer takes Apocalypse role
Fix Necromancer being unable to see reveals from revealing roles
Apocalypse can target Necromancer when Necromancer has Apocalypse role