### PR TITLE
Set spamms CustomRPC to SendOption.None & Remove Unused

### DIFF
--- a/Modules/ExtendedPlayerControl.cs
+++ b/Modules/ExtendedPlayerControl.cs
@@ -337,7 +337,7 @@ static class ExtendedPlayerControl
             player.Exiled();
             return;
         }
-        MessageWriter writer = AmongUsClient.Instance.StartRpcImmediately(player.NetId, (byte)RpcCalls.Exiled, SendOption.None, clientId);
+        MessageWriter writer = AmongUsClient.Instance.StartRpcImmediately(player.NetId, (byte)RpcCalls.Exiled, SendOption.Reliable, clientId);
         AmongUsClient.Instance.FinishRpcImmediately(writer);
     }
     public static void RpcExileV2(this PlayerControl player)
@@ -348,7 +348,7 @@ static class ExtendedPlayerControl
         }
         player.Exiled();
 
-        MessageWriter writer = AmongUsClient.Instance.StartRpcImmediately(player.NetId, (byte)RpcCalls.Exiled, SendOption.None, -1);
+        MessageWriter writer = AmongUsClient.Instance.StartRpcImmediately(player.NetId, (byte)RpcCalls.Exiled, SendOption.Reliable, -1);
         AmongUsClient.Instance.FinishRpcImmediately(writer);
     }
     public static void RpcCastVote(this PlayerControl player, byte suspectIdx)
@@ -830,7 +830,7 @@ static class ExtendedPlayerControl
         }
         else
         {
-            MessageWriter writer = AmongUsClient.Instance.StartRpcImmediately(target.NetId, (byte)RpcCalls.ProtectPlayer, SendOption.None, target.GetClientId());
+            MessageWriter writer = AmongUsClient.Instance.StartRpcImmediately(target.NetId, (byte)RpcCalls.ProtectPlayer, RpcSendOption, target.GetClientId());
             writer.WriteNetObject(target);
             writer.Write(0);
             AmongUsClient.Instance.FinishRpcImmediately(writer);

--- a/Modules/RPC.cs
+++ b/Modules/RPC.cs
@@ -1043,7 +1043,7 @@ public class StartRpcImmediatelyPatch
 {
     public static bool Prefix(InnerNetClient __instance, [HarmonyArgument(0)] uint targetNetId, [HarmonyArgument(1)] byte callId, [HarmonyArgument(2)] SendOption option, [HarmonyArgument(3)] int targetClientId, ref MessageWriter __result)
     {
-        if (callId < (byte)CustomRPC.VersionCheck || !AmongUsClient.Instance.AmHost || !GameStates.IsVanillaServer || GameStates.IsLocalGame || option is SendOption.None)
+        if (!AmongUsClient.Instance.AmHost || !GameStates.IsVanillaServer || GameStates.IsLocalGame || option is SendOption.None)
         {
             RPC.SendRpcLogger(targetNetId, callId, option, targetClientId);
             return true;

--- a/Modules/RPC.cs
+++ b/Modules/RPC.cs
@@ -16,13 +16,15 @@ using static TOHE.Translator;
 namespace TOHE;
 
 [Obfuscation(Exclude = true)]
-public enum CustomRPC : byte // 184/255 USED
+public enum CustomRPC : byte // 174/255 USED
 {
     // RpcCalls can increase with each AU version
     // On version 2024.6.18 the last id in RpcCalls: 65
 
     // Adding Role rpcs that overrides TOHE section and changing BetterCheck will be rejected
     // Sync Role Skill can be used under most cases so you should not make a new rpc unless it's necessary
+    // NOTE: Set RPC's that are spammed to "ExtendedPlayerControl.RpcSendOption" to prevent kick due innersloth anti-cheat
+
     VersionCheck = 80,
     RequestRetryVersionCheck = 81,
     SyncCustomSettings = 100, // AUM use 101 rpc
@@ -41,12 +43,11 @@ public enum CustomRPC : byte // 184/255 USED
     ShowPopUp,
     KillFlash,
     DumpLog,
-    SyncRoleSkill,
     SetNameColorData,
     GuessKill,
     Judge,
-    KNChat = 119, // Kill network chat, may conflicts with judge and guess calls
     Guess,
+    KNChat = 119, // Kill network chat, may conflicts with judge and guess calls
     CouncillorJudge,
     NemesisRevenge,
     RetributionistRevenge,
@@ -65,55 +66,47 @@ public enum CustomRPC : byte // 184/255 USED
     SyncAbilityUseLimit,
 
     //Roles 
+    SyncRoleSkill,
     SetBountyTarget,
     SyncPuppet,
-    SyncKami,
     SetKillOrSpell,
     SetKillOrHex,
-    SetKillOrCurse,
     SetDousedPlayer,
     DoSpell,
     DoHex,
-    DoCurse,
     SniperSync,
     SetLoversPlayers,
     SendFireworkerState,
+    SetCurrentDousingTarget,
+    SetEvilTrackerTarget,
+    SetDrawPlayer,
 
     // BetterAmongUs (BAU) RPC, This is sent to allow other BAU users know who's using BAU!
     BetterCheck = 150,
 
-    SetCurrentDousingTarget,
-    SetEvilTrackerTarget,
-    SetDrawPlayer,
     SetCrewpostorTasksDone,
     SetCurrentDrawTarget,
-    RpcPassBomb,
-    SyncRomanticTarget,
-    SyncVengefulRomanticTarget,
     SyncJailerData,
     SetInspectorLimit,
     KeeperRPC,
     SetAlchemistTimer,
     UndertakerLocationSync,
     LightningSetGhostPlayer,
-    SetDarkHiderKillCount,
     SetConsigliere,
     SetGreedy,
     BenefactorRPC,
     SetSwapperVotes,
     SetMarkedPlayer,
-    SetConcealerTimer,
     PresidentEnd,
     PresidentReveal,
-    SetBKTimer,
     SetInvestgatorLimit,
     SetOverseerRevealedPlayer,
     SetOverseerTimer,
     SetChameleonTimer,
     SyncAdmiredList,
-    SetImitateLimit,
     DictatorRPC,
     Necronomicon,
+
     //FFA
     SyncFFAPlayer,
     SyncFFANameNotify,

--- a/Modules/RPC.cs
+++ b/Modules/RPC.cs
@@ -1041,7 +1041,7 @@ internal class StartRpcPatch
 [HarmonyPatch(typeof(InnerNetClient), nameof(InnerNetClient.StartRpcImmediately))]
 public class StartRpcImmediatelyPatch
 {
-    public static void Prefix(InnerNetClient __instance, [HarmonyArgument(0)] uint targetNetId, [HarmonyArgument(1)] byte callId, [HarmonyArgument(2)] SendOption option, [HarmonyArgument(3)] int targetClientId, ref MessageWriter __result)
+    public static void Prefix(InnerNetClient __instance, [HarmonyArgument(0)] uint targetNetId, [HarmonyArgument(1)] byte callId, [HarmonyArgument(2)] SendOption option, [HarmonyArgument(3)] int targetClientId)
     {
         RPC.SendRpcLogger(targetNetId, callId, option, targetClientId);
     }

--- a/Modules/RPC.cs
+++ b/Modules/RPC.cs
@@ -1041,32 +1041,8 @@ internal class StartRpcPatch
 [HarmonyPatch(typeof(InnerNetClient), nameof(InnerNetClient.StartRpcImmediately))]
 public class StartRpcImmediatelyPatch
 {
-    public static bool Prefix(InnerNetClient __instance, [HarmonyArgument(0)] uint targetNetId, [HarmonyArgument(1)] byte callId, [HarmonyArgument(2)] SendOption option, [HarmonyArgument(3)] int targetClientId, ref MessageWriter __result)
+    public static void Prefix(InnerNetClient __instance, [HarmonyArgument(0)] uint targetNetId, [HarmonyArgument(1)] byte callId, [HarmonyArgument(2)] SendOption option, [HarmonyArgument(3)] int targetClientId, ref MessageWriter __result)
     {
-        if (!AmongUsClient.Instance.AmHost || !GameStates.IsVanillaServer || GameStates.IsLocalGame || option is SendOption.None)
-        {
-            RPC.SendRpcLogger(targetNetId, callId, option, targetClientId);
-            return true;
-        }
-
-        MessageWriter messageWriter = MessageWriter.Get(SendOption.None);
-        if (targetClientId < 0)
-        {
-            messageWriter.StartMessage(5);
-            messageWriter.Write(AmongUsClient.Instance.GameId);
-        }
-        else
-        {
-            messageWriter.StartMessage(6);
-            messageWriter.Write(AmongUsClient.Instance.GameId);
-            messageWriter.WritePacked(targetClientId);
-        }
-        messageWriter.StartMessage(2);
-        messageWriter.WritePacked(targetNetId);
-        messageWriter.Write(callId);
-
-        __result = messageWriter;
-        RPC.SendRpcLogger(targetNetId, callId, SendOption.None, targetClientId);
-        return false;
+        RPC.SendRpcLogger(targetNetId, callId, option, targetClientId);
     }
 }

--- a/Roles/Coven/PotionMaster.cs
+++ b/Roles/Coven/PotionMaster.cs
@@ -122,7 +122,7 @@ internal class PotionMaster : CovenManager
     }
 
     public static bool IsReveal(byte seer, byte target) => RevealList[seer].Contains(target);
-    private void SetRitual(PlayerControl killer, PlayerControl target)
+    private static void SetRitual(PlayerControl killer, PlayerControl target)
     {
         switch (PotionMode)
         {

--- a/Roles/Coven/Sacrifist.cs
+++ b/Roles/Coven/Sacrifist.cs
@@ -74,7 +74,7 @@ internal class Sacrifist : CovenManager
         maxDebuffTimer = DebuffCooldown.GetFloat();
         VisionChange[playerId] = [];
     }
-    public void SendRPC(PlayerControl pc)
+    private static void SendRPC(PlayerControl pc)
     {
         MessageWriter writer = AmongUsClient.Instance.StartRpcImmediately(PlayerControl.LocalPlayer.NetId, (byte)CustomRPC.SyncRoleSkill, SendOption.Reliable, pc.GetClientId());
         writer.Write(DebuffID);

--- a/Roles/Crewmate/Alchemist.cs
+++ b/Roles/Crewmate/Alchemist.cs
@@ -140,8 +140,8 @@ internal class Alchemist : RoleBase
 
     private static void SendRPC(PlayerControl pc)
     {
-        if (pc.IsHost()) return;
-        MessageWriter writer = AmongUsClient.Instance.StartRpcImmediately(PlayerControl.LocalPlayer.NetId, (byte)CustomRPC.SetAlchemistTimer, SendOption.Reliable, pc.GetClientId());
+        if (!pc.IsNonHostModdedClient()) return;
+        MessageWriter writer = AmongUsClient.Instance.StartRpcImmediately(PlayerControl.LocalPlayer.NetId, (byte)CustomRPC.SetAlchemistTimer, ExtendedPlayerControl.RpcSendOption, pc.GetClientId());
         writer.Write(FixNextSabo);
         writer.Write(PotionID);
         writer.Write((InvisTime.TryGetValue(pc.PlayerId, out var x) ? x : -1).ToString());

--- a/Roles/Crewmate/Chameleon.cs
+++ b/Roles/Crewmate/Chameleon.cs
@@ -53,6 +53,7 @@ internal class Chameleon : RoleBase
     }
     public static void SendRPC(PlayerControl pc)
     {
+        if (!pc.IsNonHostModdedClient()) return;
         MessageWriter writer = AmongUsClient.Instance.StartRpcImmediately(PlayerControl.LocalPlayer.NetId, (byte)CustomRPC.SetChameleonTimer, ExtendedPlayerControl.RpcSendOption, pc.GetClientId());
         writer.Write(pc.PlayerId);
         writer.Write((InvisCooldown.TryGetValue(pc.PlayerId, out var y) ? y : -1).ToString());

--- a/Roles/Crewmate/Chameleon.cs
+++ b/Roles/Crewmate/Chameleon.cs
@@ -53,7 +53,7 @@ internal class Chameleon : RoleBase
     }
     public static void SendRPC(PlayerControl pc)
     {
-        MessageWriter writer = AmongUsClient.Instance.StartRpcImmediately(PlayerControl.LocalPlayer.NetId, (byte)CustomRPC.SetChameleonTimer, SendOption.Reliable, pc.GetClientId());
+        MessageWriter writer = AmongUsClient.Instance.StartRpcImmediately(PlayerControl.LocalPlayer.NetId, (byte)CustomRPC.SetChameleonTimer, ExtendedPlayerControl.RpcSendOption, pc.GetClientId());
         writer.Write(pc.PlayerId);
         writer.Write((InvisCooldown.TryGetValue(pc.PlayerId, out var y) ? y : -1).ToString());
         writer.Write((InvisDuration.TryGetValue(pc.PlayerId, out var x) ? x : -1).ToString());

--- a/Roles/Crewmate/Overseer.cs
+++ b/Roles/Crewmate/Overseer.cs
@@ -108,7 +108,7 @@ internal class Overseer : RoleBase
 
     private static void SendTimerRPC(byte RpcType, byte overseertId, PlayerControl target = null, float timer = 0)
     {
-        MessageWriter writer = AmongUsClient.Instance.StartRpcImmediately(PlayerControl.LocalPlayer.NetId, (byte)CustomRPC.SetOverseerTimer, SendOption.Reliable, -1);
+        MessageWriter writer = AmongUsClient.Instance.StartRpcImmediately(PlayerControl.LocalPlayer.NetId, (byte)CustomRPC.SetOverseerTimer, ExtendedPlayerControl.RpcSendOption);
         writer.Write(RpcType);
         writer.Write(overseertId);
         if (target != null && RpcType == 1)

--- a/Roles/Impostor/Swooper.cs
+++ b/Roles/Impostor/Swooper.cs
@@ -48,7 +48,7 @@ internal class Swooper : RoleBase
     private void SendRPC(PlayerControl pc)
     {
         if (!pc.IsNonHostModdedClient()) return;
-        MessageWriter writer = AmongUsClient.Instance.StartRpcImmediately(PlayerControl.LocalPlayer.NetId, (byte)CustomRPC.SyncRoleSkill, SendOption.Reliable, pc.GetClientId());
+        MessageWriter writer = AmongUsClient.Instance.StartRpcImmediately(PlayerControl.LocalPlayer.NetId, (byte)CustomRPC.SyncRoleSkill, ExtendedPlayerControl.RpcSendOption, pc.GetClientId());
         writer.WriteNetObject(_Player);
         writer.Write(InvisCooldown.GetValueOrDefault(pc.PlayerId, -1).ToString());
         writer.Write(InvisDuration.GetValueOrDefault(pc.PlayerId, -1).ToString());

--- a/Roles/Neutral/Wraith.cs
+++ b/Roles/Neutral/Wraith.cs
@@ -50,7 +50,7 @@ internal class Wraith : RoleBase
     private void SendRPC(PlayerControl pc)
     {
         if (!pc.IsNonHostModdedClient()) return;
-        MessageWriter writer = AmongUsClient.Instance.StartRpcImmediately(PlayerControl.LocalPlayer.NetId, (byte)CustomRPC.SyncRoleSkill, SendOption.Reliable, pc.GetClientId());
+        MessageWriter writer = AmongUsClient.Instance.StartRpcImmediately(PlayerControl.LocalPlayer.NetId, (byte)CustomRPC.SyncRoleSkill, ExtendedPlayerControl.RpcSendOption, pc.GetClientId());
         writer.WriteNetObject(_Player);//SetWraithTimer
         writer.Write((InvisTime.TryGetValue(pc.PlayerId, out var x) ? x : -1).ToString());
         writer.Write((lastTime.TryGetValue(pc.PlayerId, out var y) ? y : -1).ToString());


### PR DESCRIPTION
Instead of sending every CustomRPC as `SendOption.None`, it is better to send only spammed Rpc as `SendOption.None`