### PR TITLE
Runner can see other players roles and status in Speedrun

### DIFF
--- a/GameModes/SpeedRun.cs
+++ b/GameModes/SpeedRun.cs
@@ -296,7 +296,7 @@ public static class SpeedRun
             playerInfoList.Add((playerId, playerName, isAlive, finishedTasks, kills, finishTime, completedTasks, totalTasks));
         }
 
-        // Alive > Finish all tasks > Kill num > Time cost to finish all tasks > Not yet finish tasks then task num
+        // Alive > Finish all tasks > Kill number > Time cost to finish all tasks > Not yet finish tasks then task number
         playerInfoList = playerInfoList.OrderByDescending(p => p.isAlive)
                                      .ThenByDescending(p => p.finishedTasks)
                                      .ThenByDescending(p => p.kills)
@@ -641,4 +641,8 @@ public class Runner : RoleBase
             return ColorString(Color.red, string.Format(GetString("KillCount"), SpeedRun.PlayerNumKills[playerId]));
         }
     }
+
+    public override bool KnowRoleTarget(PlayerControl seer, PlayerControl target) => seer.Is(CustomRoles.Runner);
+    
+    public override string PlayerKnowTargetColor(PlayerControl seer, PlayerControl target) => Main.roleColors[target.GetCustomRole()];
 }


### PR DESCRIPTION
Since modded clients can see all players status on the task panel, vanilla clients should have the same ability to see them above their character.