### PR TITLE
Patch RpcClose to send setname calls

### DIFF
--- a/Roles/Crewmate/Dictator.cs
+++ b/Roles/Crewmate/Dictator.cs
@@ -113,12 +113,12 @@ internal class Dictator : RoleBase
             }
             else
             {
-                MeetingHud.Instance.RpcVotingComplete(states, exiled, false);
-
                 if (exiled != null)
                 {
                     CheckForEndVotingPatch.ConfirmEjections(exiled);
                 }
+
+                MeetingHud.Instance.RpcVotingComplete(states, exiled, false);
             }
 
             Logger.Info($"{target.GetNameWithRole()} expelled by Dictator", "Dictator");


### PR DESCRIPTION
Doesnt work

Some function can call MeetingHud.Close without using RpcClose.

I can't find this function in dnSpy