### PR TITLE
Improvements to Vigilante

### DIFF
--- a/Modules/CustomRolesHelper.cs
+++ b/Modules/CustomRolesHelper.cs
@@ -244,6 +244,7 @@ public static class CustomRolesHelper
             || target.Is(CustomRoles.CopyCat)
             || target.Is(CustomRoles.Telecommunication) && Telecommunication.CanUseVent()
             || Knight.CheckCanUseVent(target)
+            || Vigilante.CheckCanUseVent(target)
             || target.Is(CustomRoles.Nimble);
     }
     public static bool IsNeutral(this CustomRoles role)
@@ -977,6 +978,7 @@ public static class CustomRolesHelper
 
             case CustomRoles.Nimble:
                 if (Knight.CheckCanUseVent(pc)
+                    || Vigilante.CheckCanUseVent(pc)
                     || pc.Is(CustomRoles.CopyCat))
                     return false;
                 if (!pc.GetCustomRole().IsTasklessCrewmate())

--- a/Resources/Lang/en_US.json
+++ b/Resources/Lang/en_US.json
@@ -1573,7 +1573,7 @@
   "ConvertedVigilanteCanVent": "Converted Vigilante can Vent",
   "CanSabotageAsRecruit": "Can Sabotage as <color=#00b4eb>Recruit</color>",
   "VigilanteNotify": "You have become the very thing you swore to destroy",
-  
+
   "DictatorChangeCommandToExpel": "<color=#df9b00>Dictator</color> use Command to expell instead of vote",
   "DictatorExpelSelf": "WAIT WAIT WAIT WAT THE HELLLLLL Bro really just want to expel himself",
   "DoctorTaskCompletedBatteryCharge": "Battery Duration",

--- a/Resources/Lang/en_US.json
+++ b/Resources/Lang/en_US.json
@@ -1570,8 +1570,10 @@
   "ReverieResetCooldownMeeting": "Reset Kill Cooldown after meeting",
   "ConvertedReverieKillAll": "Converted Reverie can kill anyone without repercussions",
 
+  "ConvertedVigilanteCanVent": "Converted Vigilante can Vent",
+  "CanSabotageAsRecruit": "Can Sabotage as <color=#00b4eb>Recruit</color>",
   "VigilanteNotify": "You have become the very thing you swore to destroy",
-
+  
   "DictatorChangeCommandToExpel": "<color=#df9b00>Dictator</color> use Command to expell instead of vote",
   "DictatorExpelSelf": "WAIT WAIT WAIT WAT THE HELLLLLL Bro really just want to expel himself",
   "DoctorTaskCompletedBatteryCharge": "Battery Duration",

--- a/Roles/Crewmate/Vigilante.cs
+++ b/Roles/Crewmate/Vigilante.cs
@@ -15,6 +15,8 @@ internal class Vigilante : RoleBase
     //==================================================================\\
 
     private static OptionItem VigilanteKillCooldown;
+    private static OptionItem ConvertedVigilanteCanVent;
+    private static OptionItem CanSabotageAsRecruit;
 
     public override void SetupCustomOption()
     {
@@ -22,9 +24,16 @@ internal class Vigilante : RoleBase
         VigilanteKillCooldown = FloatOptionItem.Create(Id + 2, GeneralOption.KillCooldown, new(5f, 180f, 2.5f), 30f, TabGroup.CrewmateRoles, false)
             .SetParent(CustomRoleSpawnChances[CustomRoles.Vigilante])
             .SetValueFormat(OptionFormat.Seconds);
+        ConvertedVigilanteCanVent = BooleanOptionItem.Create(Id + 3, "ConvertedVigilanteCanVent", false, TabGroup.CrewmateRoles, false)
+            .SetParent(CustomRoleSpawnChances[CustomRoles.Vigilante]);
+        CanSabotageAsRecruit = BooleanOptionItem.Create(Id + 4, "CanSabotageAsRecruit", false, TabGroup.CrewmateRoles, false)
+            .SetParent(CustomRoleSpawnChances[CustomRoles.Vigilante]);
     }
     public override void SetKillCooldown(byte id) => Main.AllPlayerKillCooldown[id] = VigilanteKillCooldown.GetFloat();
     public override bool CanUseKillButton(PlayerControl pc) => true;
+    public static bool CheckCanUseVent(PlayerControl player) => player.Is(CustomRoles.Madmate) || player.IsAnySubRole(sub => sub.IsConverted() && ConvertedVigilanteCanVent.GetBool());
+    public override bool CanUseImpostorVentButton(PlayerControl pc) => CheckCanUseVent(pc);
+    public override bool CanUseSabotage(PlayerControl player) => player.Is(CustomRoles.Madmate) || player.Is(CustomRoles.Recruit) && CanSabotageAsRecruit.GetBool();
     public override bool OnCheckMurderAsKiller(PlayerControl killer, PlayerControl target)
     {
         if (killer.Is(CustomRoles.Madmate)) return true;
@@ -35,7 +44,6 @@ internal class Vigilante : RoleBase
             {
                 killer.Notify(Utils.ColorString(Utils.GetRoleColor(CustomRoles.Madmate), GetString("VigilanteNotify")));
             }, target.Is(CustomRoles.Burst) ? Burst.BurstKillDelay.GetFloat() : 0f, "BurstKillCheck");
-            //Utils.NotifyRoles(SpecifySeer: killer);
             Utils.MarkEveryoneDirtySettings();
         }
         return true;


### PR DESCRIPTION
A way to let Vigilante have a time in game bc usually when /kcount is enabled, players can see that a Madmate has appeared and they mostly target to guess that role when that happens.